### PR TITLE
Quick fix for `Compute Image Name`

### DIFF
--- a/.github/workflows/build_devcontainer.yml
+++ b/.github/workflows/build_devcontainer.yml
@@ -28,13 +28,13 @@ jobs:
             version: 14
           - kind: llvm
             version: 19
-    name: Update devcontainer ${{ matrix.kind }}-${{ matrix.version }}
+    name: "devcontainer: ${{ matrix.kind }}-${{ matrix.version }}"
     steps:
       - name: Compute Image Name
         id: image_name
         run: |
           image_name=${{ env.DEPLOY_IMAGE_NAME }}
-          if [ "${{ github.repository }}/${{ github.ref }}" != "beman/infra/refs/heads/main" ]; then
+          if [ "${{ github.repository }}/${{ github.ref }}" != "bemanproject/infra/refs/heads/main" ]; then
               image_name=${{ env.DEBUG_IMAGE_NAME }}
           fi
           echo "computed image name: $image_name"


### PR DESCRIPTION
The original intend of the CI script is to upload devcontainer image to `bemanproject/devcontainers` instead of `bemanproject/infra`.

However there's some error in my code, for the details, see [this](https://github.com/bemanproject/infra/actions/runs/13866311408/job/38806052877#step:2:3) workflow log.

This PR fixes that.