### PR TITLE
Fix SPDX-License-Identifiers

### DIFF
--- a/.github/workflows/build_devcontainer.yml
+++ b/.github/workflows/build_devcontainer.yml
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: 2.0 license with LLVM exceptions
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 name: Publish Beman devcontainers
 

--- a/devcontainer/README.md
+++ b/devcontainer/README.md
@@ -1,6 +1,6 @@
 # Devcontainer
 
-<!-- SPDX-License-Identifier: 2.0 license with LLVM exceptions -->
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 This folder contains the infrastructure for Beman project's
 generic devcontainer image. You can checkout available images in beman's
@@ -19,7 +19,7 @@ The image includes:
 ## Example devcontainer setup
 
 ```json
-// SPDX-License-Identifier: 2.0 license with LLVM exceptions
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 {
     "name": "Beman Generic Devcontainer",
     "image": "ghcr.io/bemanproject/devcontainers:gnu-14",


### PR DESCRIPTION
"2.0 license with LLVM exceptions" seems to be a typo for "Apache-2.0 WITH LLVM-exception".