### PR TITLE
[beman-tidy] consistently use pathlib.Path rather than os.path

### DIFF
--- a/tools/beman-submodule/beman-submodule
+++ b/tools/beman-submodule/beman-submodule
@@ -6,26 +6,29 @@ import argparse
 import configparser
 import filecmp
 import os
-import pathlib
 import shutil
 import subprocess
 import sys
 import tempfile
+from pathlib import Path
 
-def directory_compare(dir1, dir2, ignore):
+
+def directory_compare(dir1: str | Path, dir2: str | Path, ignore):
+    dir1, dir2 = Path(dir1), Path(dir2)
+
     compared = filecmp.dircmp(dir1, dir2, ignore=ignore)
     if compared.left_only or compared.right_only or compared.diff_files:
         return False
     for common_dir in compared.common_dirs:
-        path1 = os.path.join(dir1, common_dir)
-        path2 = os.path.join(dir2, common_dir)
+        path1 = dir1 / common_dir
+        path2 = dir2 / common_dir
         if not directory_compare(path1, path2, ignore):
             return False
     return True
 
 class BemanSubmodule:
-    def __init__(self, dirpath, remote, commit_hash):
-        self.dirpath = dirpath
+    def __init__(self, dirpath: str | Path, remote: str, commit_hash: str):
+        self.dirpath = Path(dirpath)
         self.remote = remote
         self.commit_hash = commit_hash
 
@@ -43,22 +46,26 @@ def parse_beman_submodule_file(path):
     if not 'commit_hash' in config['beman_submodule']:
         fail()
     return BemanSubmodule(
-        str(pathlib.Path(path).resolve().parent),
-        config['beman_submodule']['remote'], config['beman_submodule']['commit_hash'])
+        Path(path).resolve().parent,
+        config['beman_submodule']['remote'], 
+        config['beman_submodule']['commit_hash'])
 
-def get_beman_submodule(dir):
-    beman_submodule_filepath = os.path.join(dir, '.beman_submodule')
-    if os.path.isfile(beman_submodule_filepath):
+def get_beman_submodule(path: str | Path):
+    beman_submodule_filepath = Path(path) / '.beman_submodule'
+
+    if beman_submodule_filepath.is_file():
         return parse_beman_submodule_file(beman_submodule_filepath)
     else:
         return None
 
-def find_beman_submodules_in(dir):
-    assert os.path.isdir(dir)
+def find_beman_submodules_in(path):
+    path = Path(path)
+    assert path.is_dir()
+
     result = []
-    for dirpath, _, filenames in os.walk(dir):
+    for dirpath, _, filenames in path.walk():
         if '.beman_submodule' in filenames:
-            result.append(parse_beman_submodule_file(os.path.join(dirpath, '.beman_submodule')))
+            result.append(parse_beman_submodule_file(dirpath / '.beman_submodule'))
     return sorted(result, key=lambda module: module.dirpath)
 
 def cwd_git_repository_path():
@@ -92,19 +99,22 @@ def beman_submodule_status(beman_submodule):
     parent_repo_path = cwd_git_repository_path()
     if not parent_repo_path:
         raise Exception('this is not a git repository')
-    relpath = pathlib.Path(
-        beman_submodule.dirpath).relative_to(pathlib.Path(parent_repo_path))
+    relpath = Path(beman_submodule.dirpath).relative_to(Path(parent_repo_path))
     return status_character + ' ' + beman_submodule.commit_hash + ' ' + str(relpath)
 
 def beman_submodule_update(beman_submodule, remote):
     tmpdir = clone_beman_submodule_into_tmpdir(beman_submodule, remote)
+    tmp_path = Path(tmpdir.name)
+
     shutil.rmtree(beman_submodule.dirpath)
-    with open(os.path.join(tmpdir.name, '.beman_submodule'), 'w') as f:
+
+    submodule_path = tmp_path / '.beman_submodule'
+    with open(submodule_path, 'w') as f:
         f.write('[beman_submodule]\n')
         f.write(f'remote={beman_submodule.remote}\n')
         f.write(f'commit_hash={beman_submodule.commit_hash}\n')
-    shutil.rmtree(os.path.join(tmpdir.name, '.git'))
-    shutil.copytree(tmpdir.name, beman_submodule.dirpath)
+    shutil.rmtree(tmp_path / '.git')
+    shutil.copytree(tmp_path, beman_submodule.dirpath)
 
 def update_command(remote, path):
     if not path:
@@ -126,19 +136,21 @@ def add_command(repository, path):
         ['git', 'clone', repository], capture_output=True, check=True, cwd=tmpdir.name)
     repository_name = os.listdir(tmpdir.name)[0]
     if not path:
-        path = repository_name
-    if os.path.exists(path):
+        path = Path(repository_name)
+    else:
+        path = Path(path)
+    if path.exists():
         raise Exception(f'{path} exists')
-    os.makedirs(path)
-    tmpdir_repo = os.path.join(tmpdir.name, repository_name)
+    path.mkdir()
+    tmpdir_repo = Path(tmpdir.name) / repository_name
     sha_process = subprocess.run(
         ['git', 'rev-parse', 'HEAD'], capture_output=True, check=True, text=True,
         cwd=tmpdir_repo)
-    with open(os.path.join(tmpdir_repo, '.beman_submodule'), 'w') as f:
+    with open(tmpdir_repo / '.beman_submodule', 'w') as f:
         f.write('[beman_submodule]\n')
         f.write(f'remote={repository}\n')
         f.write(f'commit_hash={sha_process.stdout.strip()}\n')
-    shutil.rmtree(os.path.join(tmpdir_repo, '.git'))
+    shutil.rmtree(tmpdir_repo /'.git')
     shutil.copytree(tmpdir_repo, path, dirs_exist_ok=True)
 
 def status_command(paths):

--- a/tools/beman-submodule/test/test_beman_submodule.py
+++ b/tools/beman-submodule/test/test_beman_submodule.py
@@ -1,27 +1,29 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import os
-import pathlib
 import pytest
 import shutil
 import stat
 import subprocess
 import tempfile
+from pathlib import Path
 
 # https://stackoverflow.com/a/19011259
 import types
 import importlib.machinery
 loader = importlib.machinery.SourceFileLoader(
     'beman_submodule',
-    os.path.join(os.path.dirname(os.path.realpath(__file__)), '../beman-submodule'))
+    str(Path(__file__).parent.resolve().parent / 'beman-submodule'))
 beman_submodule = types.ModuleType(loader.name)
 loader.exec_module(beman_submodule)
 
 def create_test_git_repository():
     tmpdir = tempfile.TemporaryDirectory()
+    tmp_path = Path(tmpdir.name)
+
     subprocess.run(['git', 'init'], check=True, cwd=tmpdir.name, capture_output=True)
     def make_commit(a_txt_contents):
-        with open(os.path.join(tmpdir.name, 'a.txt'), 'w') as f:
+        with open(tmp_path / 'a.txt', 'w') as f:
             f.write(a_txt_contents)
         subprocess.run(
             ['git', 'add', 'a.txt'], check=True, cwd=tmpdir.name, capture_output=True)
@@ -34,28 +36,30 @@ def create_test_git_repository():
     return tmpdir
 
 def test_directory_compare():
-    def create_dir_structure(dir_path):
-        bar_path = os.path.join(dir_path, 'bar')
+    def create_dir_structure(dir_path: Path):
+        bar_path = dir_path / 'bar'
         os.makedirs(bar_path)
 
-        with open(os.path.join(dir_path, 'foo.txt'), 'w') as f:
+        with open(dir_path / 'foo.txt', 'w') as f:
             f.write('foo')
-        with open(os.path.join(bar_path, 'baz.txt'), 'w') as f:
+        with open(bar_path / 'baz.txt', 'w') as f:
             f.write('baz')
 
     with tempfile.TemporaryDirectory() as dir_a, \
          tempfile.TemporaryDirectory() as dir_b:
+        path_a = Path(dir_a)
+        path_b = Path(dir_b)
 
-        create_dir_structure(dir_a)
-        create_dir_structure(dir_b)
+        create_dir_structure(path_a)
+        create_dir_structure(path_b)
 
         assert beman_submodule.directory_compare(dir_a, dir_b, [])
 
-        with open(os.path.join(os.path.join(dir_a, 'bar'), 'quux.txt'), 'w') as f:
+        with open(path_a / 'bar' / 'quux.txt', 'w') as f:
             f.write('quux')
 
-        assert not beman_submodule.directory_compare(dir_a, dir_b, [])
-        assert beman_submodule.directory_compare(dir_a, dir_b, ['quux.txt'])
+        assert not beman_submodule.directory_compare(path_a, path_b, [])
+        assert beman_submodule.directory_compare(path_a, path_b, ['quux.txt'])
 
 def test_parse_beman_submodule_file():
     def valid_file():
@@ -67,7 +71,7 @@ def test_parse_beman_submodule_file():
             'commit_hash=9b88395a86c4290794e503e94d8213b6c442ae77\n'.encode('utf-8'))
         tmpfile.flush()
         module = beman_submodule.parse_beman_submodule_file(tmpfile.name)
-        assert module.dirpath == str(pathlib.Path(tmpfile.name).resolve().parent)
+        assert module.dirpath == Path(tmpfile.name).resolve().parent
         assert module.remote == 'git@github.com:bemanproject/infra.git'
         assert module.commit_hash == '9b88395a86c4290794e503e94d8213b6c442ae77'
     valid_file()
@@ -116,7 +120,7 @@ def test_parse_beman_submodule_file():
 def test_get_beman_submodule():
     tmpdir = create_test_git_repository()
     tmpdir2 = create_test_git_repository()
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     beman_submodule.add_command(tmpdir.name, 'foo')
     assert beman_submodule.get_beman_submodule('foo')
@@ -127,7 +131,7 @@ def test_get_beman_submodule():
 def test_find_beman_submodules_in():
     tmpdir = create_test_git_repository()
     tmpdir2 = create_test_git_repository()
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     beman_submodule.add_command(tmpdir.name, 'foo')
     beman_submodule.add_command(tmpdir.name, 'bar')
@@ -136,16 +140,16 @@ def test_find_beman_submodules_in():
         ['git', 'rev-parse', 'HEAD'], capture_output=True, check=True, text=True,
         cwd=tmpdir.name)
     sha = sha_process.stdout.strip()
-    assert beman_submodules[0].dirpath == os.path.join(tmpdir2.name, 'bar')
+    assert beman_submodules[0].dirpath == Path(tmpdir2.name) / 'bar'
     assert beman_submodules[0].remote == tmpdir.name
     assert beman_submodules[0].commit_hash == sha
-    assert beman_submodules[1].dirpath == os.path.join(tmpdir2.name, 'foo')
+    assert beman_submodules[1].dirpath == Path(tmpdir2.name) / 'foo'
     assert beman_submodules[1].remote == tmpdir.name
     assert beman_submodules[1].commit_hash == sha
     os.chdir(original_cwd)
 
 def test_cwd_git_repository_path():
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     tmpdir = tempfile.TemporaryDirectory()
     os.chdir(tmpdir.name)
     assert not beman_submodule.cwd_git_repository_path()
@@ -156,14 +160,14 @@ def test_cwd_git_repository_path():
 def test_clone_beman_submodule_into_tmpdir():
     tmpdir = create_test_git_repository()
     tmpdir2 = create_test_git_repository()
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     sha_process = subprocess.run(
         ['git', 'rev-parse', 'HEAD^'], capture_output=True, check=True, text=True,
         cwd=tmpdir.name)
     sha = sha_process.stdout.strip()
     beman_submodule.add_command(tmpdir.name, 'foo')
-    module = beman_submodule.get_beman_submodule(os.path.join(tmpdir2.name, 'foo'))
+    module = beman_submodule.get_beman_submodule(Path(tmpdir2.name) / 'foo')
     module.commit_hash = sha
     tmpdir3 = beman_submodule.clone_beman_submodule_into_tmpdir(module, False)
     assert not beman_submodule.directory_compare(tmpdir.name, tmpdir3.name, ['.git'])
@@ -178,7 +182,7 @@ def test_clone_beman_submodule_into_tmpdir():
 def test_beman_submodule_status():
     tmpdir = create_test_git_repository()
     tmpdir2 = create_test_git_repository()
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     beman_submodule.add_command(tmpdir.name, 'foo')
     sha_process = subprocess.run(
@@ -186,17 +190,17 @@ def test_beman_submodule_status():
         cwd=tmpdir.name)
     sha = sha_process.stdout.strip()
     assert '  ' + sha + ' foo' == beman_submodule.beman_submodule_status(
-        beman_submodule.get_beman_submodule(os.path.join(tmpdir2.name, 'foo')))
-    with open(os.path.join(os.path.join(tmpdir2.name, 'foo'), 'a.txt'), 'w') as f:
+        beman_submodule.get_beman_submodule(Path(tmpdir2.name) / 'foo'))
+    with open(Path(tmpdir2.name) / 'foo' / 'a.txt', 'w') as f:
         f.write('b')
     assert '+ ' + sha + ' foo' == beman_submodule.beman_submodule_status(
-        beman_submodule.get_beman_submodule(os.path.join(tmpdir2.name, 'foo')))
+        beman_submodule.get_beman_submodule(Path(tmpdir2.name) / 'foo'))
     os.chdir(original_cwd)
 
 def test_update_command_no_paths():
     tmpdir = create_test_git_repository()
     tmpdir2 = create_test_git_repository()
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     beman_submodule.add_command(tmpdir.name, 'foo')
     beman_submodule.add_command(tmpdir.name, 'bar')
@@ -207,15 +211,15 @@ def test_update_command_no_paths():
     subprocess.run(
         ['git', 'reset', '--hard', sha], capture_output=True, check=True,
         cwd=tmpdir.name)
-    with open(os.path.join(os.path.join(tmpdir2.name, 'foo'), '.beman_submodule'), 'w') as f:
+    with open(Path(tmpdir2.name) / 'foo' / '.beman_submodule', 'w') as f:
         f.write(f'[beman_submodule]\nremote={tmpdir.name}\ncommit_hash={sha}\n')
-    with open(os.path.join(os.path.join(tmpdir2.name, 'bar'), '.beman_submodule'), 'w') as f:
+    with open(Path(tmpdir2.name) / 'bar' / '.beman_submodule', 'w') as f:
         f.write(f'[beman_submodule]\nremote={tmpdir.name}\ncommit_hash={sha}\n')
     beman_submodule.update_command(tmpdir.name, None)
     assert beman_submodule.directory_compare(
-        tmpdir.name, os.path.join(tmpdir2.name, 'foo'), ['.git', '.beman_submodule'])
+        tmpdir.name, Path(tmpdir2.name) / 'foo', ['.git', '.beman_submodule'])
     assert beman_submodule.directory_compare(
-        tmpdir.name, os.path.join(tmpdir2.name, 'bar'), ['.git', '.beman_submodule'])
+        tmpdir.name, Path(tmpdir2.name) / 'bar', ['.git', '.beman_submodule'])
     os.chdir(original_cwd)
 
 def test_update_command_with_path():
@@ -223,7 +227,7 @@ def test_update_command_with_path():
     tmpdir2 = create_test_git_repository()
     tmpdir_copy1 = tempfile.TemporaryDirectory()
     shutil.copytree(tmpdir.name, tmpdir_copy1.name, dirs_exist_ok=True)
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     beman_submodule.add_command(tmpdir.name, 'foo')
     beman_submodule.add_command(tmpdir.name, 'bar')
@@ -234,21 +238,21 @@ def test_update_command_with_path():
     subprocess.run(
         ['git', 'reset', '--hard', sha], capture_output=True, check=True,
         cwd=tmpdir.name)
-    with open(os.path.join(os.path.join(tmpdir2.name, 'foo'), '.beman_submodule'), 'w') as f:
+    with open(Path(tmpdir2.name) / 'foo' / '.beman_submodule', 'w') as f:
         f.write(f'[beman_submodule]\nremote={tmpdir.name}\ncommit_hash={sha}\n')
-    with open(os.path.join(os.path.join(tmpdir2.name, 'bar'), '.beman_submodule'), 'w') as f:
+    with open(Path(tmpdir2.name) / 'bar' / '.beman_submodule', 'w') as f:
         f.write(f'[beman_submodule]\nremote={tmpdir.name}\ncommit_hash={sha}\n')
     beman_submodule.update_command(tmpdir.name, 'foo')
     assert beman_submodule.directory_compare(
-        tmpdir.name, os.path.join(tmpdir2.name, 'foo'), ['.git', '.beman_submodule'])
+        tmpdir.name, Path(tmpdir2.name) / 'foo', ['.git', '.beman_submodule'])
     assert beman_submodule.directory_compare(
-        tmpdir_copy1.name, os.path.join(tmpdir2.name, 'bar'), ['.git', '.beman_submodule'])
+        tmpdir_copy1.name, Path(tmpdir2.name) / 'bar', ['.git', '.beman_submodule'])
     os.chdir(original_cwd)
 
 def test_add_command():
     tmpdir = create_test_git_repository()
     tmpdir2 = create_test_git_repository()
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     beman_submodule.add_command(tmpdir.name, 'foo')
     sha_process = subprocess.run(
@@ -256,22 +260,22 @@ def test_add_command():
         cwd=tmpdir.name)
     sha = sha_process.stdout.strip()
     assert beman_submodule.directory_compare(
-        tmpdir.name, os.path.join(tmpdir2.name, 'foo'), ['.git', '.beman_submodule'])
-    with open(os.path.join(os.path.join(tmpdir2.name, 'foo'), '.beman_submodule'), 'r') as f:
+        tmpdir.name, Path(tmpdir2.name) / 'foo', ['.git', '.beman_submodule'])
+    with open(Path(tmpdir2.name) / 'foo' / '.beman_submodule', 'r') as f:
         assert f.read() == f'[beman_submodule]\nremote={tmpdir.name}\ncommit_hash={sha}\n'
     os.chdir(original_cwd)
 
 def test_status_command_no_paths(capsys):
     tmpdir = create_test_git_repository()
     tmpdir2 = create_test_git_repository()
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     beman_submodule.add_command(tmpdir.name, 'foo')
     beman_submodule.add_command(tmpdir.name, 'bar')
     sha_process = subprocess.run(
         ['git', 'rev-parse', 'HEAD'], capture_output=True, check=True, text=True,
         cwd=tmpdir.name)
-    with open(os.path.join(os.path.join(tmpdir2.name, 'bar'), 'a.txt'), 'w') as f:
+    with open(Path(tmpdir2.name) / 'bar' / 'a.txt', 'w') as f:
         f.write('b')
     beman_submodule.status_command([])
     sha = sha_process.stdout.strip()
@@ -281,14 +285,14 @@ def test_status_command_no_paths(capsys):
 def test_status_command_with_path(capsys):
     tmpdir = create_test_git_repository()
     tmpdir2 = create_test_git_repository()
-    original_cwd = os.getcwd()
+    original_cwd = Path.cwd()
     os.chdir(tmpdir2.name)
     beman_submodule.add_command(tmpdir.name, 'foo')
     beman_submodule.add_command(tmpdir.name, 'bar')
     sha_process = subprocess.run(
         ['git', 'rev-parse', 'HEAD'], capture_output=True, check=True, text=True,
         cwd=tmpdir.name)
-    with open(os.path.join(os.path.join(tmpdir2.name, 'bar'), 'a.txt'), 'w') as f:
+    with open(Path(tmpdir2.name) / 'bar' / 'a.txt', 'w') as f:
         f.write('b')
     beman_submodule.status_command(['bar'])
     sha = sha_process.stdout.strip()
@@ -298,7 +302,7 @@ def test_status_command_with_path(capsys):
 def test_check_for_git():
     tmpdir = tempfile.TemporaryDirectory()
     assert not beman_submodule.check_for_git(tmpdir.name)
-    fake_git_path = os.path.join(tmpdir.name, 'git')
+    fake_git_path = Path(tmpdir.name) / 'git'
     with open(fake_git_path, 'w'):
         pass
     os.chmod(fake_git_path, stat.S_IRWXU)

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/base_check.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from abc import ABC, abstractmethod
+from pathlib import Path
+
 from ..system.registry import get_beman_standard_check_name_by_class
 
 
@@ -43,7 +45,7 @@ class BaseCheck(ABC):
         assert "name" in repo_info
         self.repo_name = repo_info["name"]
         assert "top_level" in repo_info
-        self.repo_path = repo_info["top_level"]
+        self.repo_path = Path(repo_info["top_level"])
         assert self.repo_path is not None
         self.library_name = f"beman.{self.repo_name}"
         assert self.library_name is not None
@@ -69,7 +71,7 @@ class BaseCheck(ABC):
             self.log(f"The repo_name is not set for check = {self.name}.")
             return False
 
-        if self.repo_path is None:
+        if not self.repo_path:
             self.log(f"The repo_path is not set for check = {self.name}.")
             return False
 

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/directory_base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/directory_base_check.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from abc import abstractmethod
-import os
+from pathlib import Path
 
 from .base_check import BaseCheck
 
@@ -14,9 +14,10 @@ class DirectoryBaseCheck(BaseCheck):
 
     def __init__(self, repo_info, beman_standard_check_config, relative_path):
         super().__init__(repo_info, beman_standard_check_config)
+        print(repo_info)
 
         # set path - e.g. "src/beman/exemplar"
-        self.path = os.path.join(repo_info["top_level"], relative_path)
+        self.path = self.repo_path / relative_path
 
     def pre_check(self):
         """
@@ -30,7 +31,7 @@ class DirectoryBaseCheck(BaseCheck):
             self.log("The path is not set.")
             return False
 
-        if not os.path.exists(self.path):
+        if not self.path.exists():
             self.log(f"The directory '{self.path}' does not exist.")
             return False
 
@@ -54,12 +55,12 @@ class DirectoryBaseCheck(BaseCheck):
         """
         pass
 
-    def read(self):
+    def read(self) -> list[Path]:
         """
         Read the directory content.
         """
         try:
-            return os.listdir(self.path)
+            return list(self.path.iterdir())
         except Exception:
             return []
 

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/file_base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/file_base_check.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from abc import abstractmethod
-import os
 import re
 
 from .base_check import BaseCheck
@@ -17,7 +16,7 @@ class FileBaseCheck(BaseCheck):
         super().__init__(repo_info, beman_standard_check_config)
 
         # set path - e.g. "README.md"
-        self.path = os.path.join(repo_info["top_level"], relative_path)
+        self.path = self.repo_path / relative_path
 
     def pre_check(self):
         """
@@ -31,7 +30,7 @@ class FileBaseCheck(BaseCheck):
             self.log("The path is not set.")
             return False
 
-        if not os.path.exists(self.path):
+        if not self.path.exists():
             self.log(f"The file '{self.path}' does not exist.")
             return False
 

--- a/tools/beman-tidy/beman_tidy/lib/utils/git.py
+++ b/tools/beman-tidy/beman_tidy/lib/utils/git.py
@@ -1,27 +1,29 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import os
 import sys
 import yaml
+from pathlib import Path
+
 from git import Repo, InvalidGitRepositoryError
 
 
-def get_repo_info(path):
+def get_repo_info(path: str):
     """
     Get information about the repository at the given path.
     Returns data as a dictionary.
     """
 
+    path: Path = Path(path)
     try:
         # Initialize the repository object
-        repo = Repo(os.path.abspath(path), search_parent_directories=True)
+        repo = Repo(path.absolute(), search_parent_directories=True)
 
         # Get the top-level directory of the repository
-        top_level_dir = repo.git.rev_parse("--show-toplevel")
+        top_level_dir = Path(repo.git.rev_parse("--show-toplevel"))
 
         # Get the repository name (directory name of the top level)
-        repo_name = os.path.basename(top_level_dir)
+        repo_name = top_level_dir.name
 
         # Get the remote URL (assuming 'origin' is the remote name)
         remote_url = None
@@ -62,7 +64,7 @@ def get_beman_standard_config_path():
     """
     Get the path to the Beman Standard YAML configuration file.
     """
-    return os.path.join(os.path.dirname(__file__), "..", "..", ".beman-standard.yml")
+    return Path(__file__).parent.parent.parent / ".beman-standard.yml"
 
 
 def load_beman_standard_config(path=get_beman_standard_config_path()):

--- a/tools/beman-tidy/tests/utils/file_testcase_runners.py
+++ b/tools/beman-tidy/tests/utils/file_testcase_runners.py
@@ -2,11 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import os
-
+from pathlib import Path
 
 def file_testcase_run(file_path, check_class, repo_info, beman_standard_check_config, expected_result):
     check_instance = check_class(repo_info, beman_standard_check_config)
-    check_instance.path = file_path
+    check_instance.path = Path(file_path)
     check_instance.log_level = True
 
     assert check_instance.pre_check(
@@ -27,7 +27,7 @@ def file_testcase_run_invalid(file_path, check_class, repo_info, beman_standard_
 
 def file_testcase_run_fix_invalid(invalid_file_path, check_class, repo_info, beman_standard_check_config):
     check_instance = check_class(repo_info, beman_standard_check_config)
-    check_instance.path = f"{invalid_file_path}.delete_me"
+    check_instance.path = Path(f"{invalid_file_path}.delete_me")
     check_instance.write(invalid_file_path.read_text())
 
     assert check_instance.pre_check() is True


### PR DESCRIPTION
The beman-tidy code base has mixed usage of os.path and pathlib.Path. The latter is to be preferred.

This is the first patch in a series of patches wrt https://github.com/bemanproject/infra/issues/89. I've submitted it as separate PR to make reviewing easier.