### PR TITLE
beman-tidy: implement TOPLEVEL.LICENSE and TOPLEVEL:README

### DIFF
--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -50,6 +50,5 @@ class ToplevelReadmeCheck(ReadmeBaseCheck):
         return super().pre_check()
     
     def fix(self):
-        # TODO: Implement the fix.
-        pass
+        self.log("Please write a README file.")
 

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -27,7 +27,7 @@ class ToplevelCmakeCheck(CMakeBaseCheck):
 @register_beman_standard_check("TOPLEVEL.LICENSE")
 class ToplevelLicenseCheck(FileBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
-        super().__init__(repo_info, beman_standard_check_config)
+        super().__init__(repo_info, beman_standard_check_config, "LICENSE")
 
     def check(self):
         # since this class simply checks for the existence of a LICENSE file,

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .cmake import CMakeBaseCheck
-from ..base.file_base_check import FileBaseCheck
+from .license import LicenseBaseCheck
 from .readme import ReadmeBaseCheck
 from ..system.registry import register_beman_standard_check
 
@@ -26,9 +26,9 @@ class ToplevelCmakeCheck(CMakeBaseCheck):
 
 
 @register_beman_standard_check("TOPLEVEL.LICENSE")
-class ToplevelLicenseCheck(FileBaseCheck):
+class ToplevelLicenseCheck(LicenseBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
-        super().__init__(repo_info, beman_standard_check_config, "LICENSE")
+        super().__init__(repo_info, beman_standard_check_config)
 
     def check(self):
         # since this class simply checks for the existence of a LICENSE file,

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -34,7 +34,6 @@ class ToplevelLicenseCheck(FileBaseCheck):
         # there's nothing more to do than the default pre-check.
         return super().pre_check()
         return True
-    
     def fix(self):
         # TODO: Implement the fix.
         pass
@@ -48,7 +47,5 @@ class ToplevelReadmeCheck(ReadmeBaseCheck):
         # since this class simply checks for the existence of a README file,
         # there's nothing more to do than the default pre-check.
         return super().pre_check()
-    
     def fix(self):
         self.log("Please write a README file.")
-

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -24,6 +24,7 @@ class ToplevelCmakeCheck(CMakeBaseCheck):
         # TODO: Implement the fix.
         pass
 
+
 @register_beman_standard_check("TOPLEVEL.LICENSE")
 class ToplevelLicenseCheck(FileBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
@@ -33,9 +34,12 @@ class ToplevelLicenseCheck(FileBaseCheck):
         # since this class simply checks for the existence of a LICENSE file,
         # there's nothing more to do than the default pre-check.
         return super().pre_check()
+
     def fix(self):
-        # TODO: Implement the fix.
-        pass
+        self.log(
+            "Please add a LICENSE file to the repository. See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#license for more information."
+        )
+
 
 @register_beman_standard_check("TOPLEVEL.README")
 class ToplevelReadmeCheck(ReadmeBaseCheck):
@@ -46,5 +50,8 @@ class ToplevelReadmeCheck(ReadmeBaseCheck):
         # since this class simply checks for the existence of a README file,
         # there's nothing more to do than the default pre-check.
         return super().pre_check()
+
     def fix(self):
-        self.log("Please write a README file.")
+        self.log(
+            "Please write a README file. See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#readmemd for the desired format."
+        )

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -33,7 +33,6 @@ class ToplevelLicenseCheck(FileBaseCheck):
         # since this class simply checks for the existence of a LICENSE file,
         # there's nothing more to do than the default pre-check.
         return super().pre_check()
-        return True
     def fix(self):
         # TODO: Implement the fix.
         pass

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -3,7 +3,7 @@
 
 from .cmake import CMakeBaseCheck
 from ..base.file_base_check import FileBaseCheck
-from ..base.readme_base_check import ReadmeBaseCheck
+from .readme import ReadmeBaseCheck
 from ..system.registry import register_beman_standard_check
 
 # [TOPLEVEL.*] checks category.

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -30,21 +30,9 @@ class ToplevelLicenseCheck(FileBaseCheck):
         super().__init__(repo_info, beman_standard_check_config)
 
     def check(self):
-        self.path = self.repo_path / self.config["file_name"]
-
-        if not self.path.exists():
-            self.log("The LICENSE file does not exist.")
-            return False
-
-        try:
-            with open(self.path, 'r') as file:
-                if len(file.read()) == 0:
-                    self.log("The LICENSE file is empty.")
-                    return False
-        except Exception:
-            self.log("Failed to read the LICENSE file.")
-            return False
-
+        # since this class simply checks for the existence of a LICENSE file,
+        # there's nothing more to do than the default pre-check.
+        return super().pre_check()
         return True
     
     def fix(self):
@@ -57,22 +45,9 @@ class ToplevelReadmeCheck(ReadmeBaseCheck):
         super().__init__(repo_info, beman_standard_check_config)
 
     def check(self):
-        self.path = self.repo_path / self.config["file_name"]
-
-        if not self.path.exists():
-            self.log("The README file does not exist.")
-            return False
-
-        try:
-            with open(self.path, 'r') as file:
-                if len(file.read()) == 0:
-                    self.log("The README file is empty.")
-                    return False
-        except Exception:
-            self.log("Failed to read the README file.")
-            return False
-
-        return True
+        # since this class simply checks for the existence of a README file,
+        # there's nothing more to do than the default pre-check.
+        return super().pre_check()
     
     def fix(self):
         # TODO: Implement the fix.

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .cmake import CMakeBaseCheck
+from ..base.file_base_check import FileBaseCheck
+from ..base.readme_base_check import ReadmeBaseCheck
 from ..system.registry import register_beman_standard_check
 
 # [TOPLEVEL.*] checks category.
@@ -22,7 +24,57 @@ class ToplevelCmakeCheck(CMakeBaseCheck):
         # TODO: Implement the fix.
         pass
 
+@register_beman_standard_check("TOPLEVEL.LICENSE")
+class ToplevelLicenseCheck(FileBaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
 
-# TODO TOPLEVEL.LICENSE - use FileBaseCheck
+    def check(self):
+        self.path = self.repo_path / self.config["file_name"]
 
-# TODO TOPLEVEL.README - use ReadmeBaseCheck
+        if not self.path.exists():
+            self.log("The LICENSE file does not exist.")
+            return False
+
+        try:
+            with open(self.path, 'r') as file:
+                if len(file.read()) == 0:
+                    self.log("The LICENSE file is empty.")
+                    return False
+        except Exception:
+            self.log("Failed to read the LICENSE file.")
+            return False
+
+        return True
+    
+    def fix(self):
+        # TODO: Implement the fix.
+        pass
+
+@register_beman_standard_check("TOPLEVEL.README")
+class ToplevelLicenseCheck(ReadmeBaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def check(self):
+        self.path = self.repo_path / self.config["file_name"]
+
+        if not self.path.exists():
+            self.log("The README file does not exist.")
+            return False
+
+        try:
+            with open(self.path, 'r') as file:
+                if len(file.read()) == 0:
+                    self.log("The README file is empty.")
+                    return False
+        except Exception:
+            self.log("Failed to read the README file.")
+            return False
+
+        return True
+    
+    def fix(self):
+        # TODO: Implement the fix.
+        pass
+

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -52,7 +52,7 @@ class ToplevelLicenseCheck(FileBaseCheck):
         pass
 
 @register_beman_standard_check("TOPLEVEL.README")
-class ToplevelLicenseCheck(ReadmeBaseCheck):
+class ToplevelReadmeCheck(ReadmeBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
         super().__init__(repo_info, beman_standard_check_config)
 

--- a/tools/beman-tidy/beman_tidy/lib/utils/git.py
+++ b/tools/beman-tidy/beman_tidy/lib/utils/git.py
@@ -99,7 +99,7 @@ def load_beman_standard_config(path=get_beman_standard_config_path()):
                 # TODO: Implement the regex check.
                 pass
             elif "file_name" in entry:
-                pass
+                check_config["file_name"] = entry["file_name"]
             elif "directory_name" in entry:
                 pass
             elif "values" in entry:


### PR DESCRIPTION
Simple checks to ensure that the top-level LICENSE and README files exist and are not empty.

I did my best to follow the example of #90.

I'm not sure how to test these top-level checks, so I didn't add any. Plus, I saw that #90 didn't add any tests either.

Addresses the `check()` parts of #53 and #54.