### PR TITLE
pre-commit: Add exemplar's checks, make them pass, add them to CI

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,78 @@
+name: Lint Check (pre-commit)
+
+on:
+  # We have to use pull_request_target here as pull_request does not grant
+  # enough permission for reviewdog
+  pull_request_target:
+  push:
+    branches:
+      - main
+
+jobs:
+  pre-commit-push:
+    name: Pre-Commit check on Push
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+        # We wish to run pre-commit on all files instead of the changes
+        # only made in the push commit.
+        #
+        # So linting error persists when there's formatting problem.
+      - uses: pre-commit/action@v3.0.1
+
+  pre-commit-pr:
+    name: Pre-Commit check on PR
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request_target' }}
+
+    permissions:
+      contents: read
+      checks: write
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+        # pull_request_target checkout the base of the repo
+        # We need to checkout the actual pr to lint the changes.
+      - name: Checkout pr
+        run: gh pr checkout ${{ github.event.number }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.13
+
+        # we only lint on the changed file in PR.
+      - name: Get Changed Files
+        id: changed-files
+        uses: tj-actions/changed-files@v45
+
+        # See:
+        # https://github.com/tj-actions/changed-files?tab=readme-ov-file#using-local-git-directory-
+      - uses: pre-commit/action@v3.0.1
+        id: run-pre-commit
+        with:
+          extra_args: --files ${{ steps.changed-files.outputs.all_changed_files }}
+
+        # Review dog posts the suggested change from pre-commit to the pr.
+      - name: suggester / pre-commit
+        uses: reviewdog/action-suggester@v1
+        if: ${{ failure() && steps.run-pre-commit.conclusion == 'failure' }}
+        with:
+          tool_name: pre-commit
+          level: warning
+          reviewdog_flags: "-fail-level=error"

--- a/.gitignore
+++ b/.gitignore
@@ -57,4 +57,3 @@ beman_tidy.egg-info/
 *.egg-info/
 build/
 dist/
-

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+    -   id: trailing-whitespace
+    -   id: end-of-file-fixer
+    -   id: check-yaml
+    -   id: check-added-large-files
+
+    # Markdown linting
+    # Config file: .markdownlint.yaml
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.42.0
+    hooks:
+    - id: markdownlint
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.3.0
+    hooks:
+      - id: codespell

--- a/tools/beman-submodule/beman-submodule
+++ b/tools/beman-submodule/beman-submodule
@@ -47,7 +47,7 @@ def parse_beman_submodule_file(path):
         fail()
     return BemanSubmodule(
         Path(path).resolve().parent,
-        config['beman_submodule']['remote'], 
+        config['beman_submodule']['remote'],
         config['beman_submodule']['commit_hash'])
 
 def get_beman_submodule(path: str | Path):

--- a/tools/beman-tidy/README.md
+++ b/tools/beman-tidy/README.md
@@ -6,10 +6,12 @@ SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 ## Description
 
-`beman-tidy` is a tool used to check and apply [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md).
+`beman-tidy` is a tool used to check and apply
+[The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md).
 
 Purpose: The tool is used to `check` (`--dry-run`) and `apply` (`--fix-inplace`) the Beman Standard to a repository.
-Note: `2025-06-07`: In order to make the best and quickly use of the tool in the entire organization, most of the checks will not support the `--fix-inplace` flag in the first iteration.
+Note: `2025-06-07`: In order to make the best and quickly use of the tool in the entire organization, most of the
+checks will not support the `--fix-inplace` flag in the first iteration.
 
 ## Installation
 
@@ -18,8 +20,8 @@ Note: `2025-06-07`: In order to make the best and quickly use of the tool in the
 - You can use beman-tidy as a pre-commit hook or install it on your system using `pipx`
 
 ```shell
-$ uv build
-$ pipx install path/to/wheel
+uv build
+pipx install path/to/wheel
 ```
 
 <details>
@@ -49,7 +51,7 @@ usage: beman-tidy [-h] [--fix-inplace | --no-fix-inplace] [--verbose | --no-verb
 
 ## Usage
 
-* Display help:
+- Display help:
 
 ```shell
 $ uv run beman-tidy --help
@@ -69,8 +71,7 @@ options:
   --checks CHECKS       array of checks to run
 ```
 
-* Run beman-tidy on the exemplar repository **(default: dry-run mode)**
-
+- Run beman-tidy on the exemplar repository **(default: dry-run mode)**
 
 ```shell
 # dry-run, require-all, non-verbose
@@ -92,23 +93,24 @@ Note: RECOMMENDATIONs are not included (--require-all NOT set).
 ```
 
 or verbose mode:
+
 ```shell
 # dry-run, require-all, verbose mode - no errors
 $ uv run beman-tidy /path/to/exemplar --require-all --verbose
 beman-tidy pipeline started ...
 
 Running check [RECOMMENDATION][README.TITLE] ...
-	check [RECOMMENDATION][README.TITLE] ... PASSED
+    check [RECOMMENDATION][README.TITLE] ... PASSED
 
 Running check [REQUIREMENT][README.BADGES] ...
-	check [REQUIREMENT][README.BADGES] ... PASSED
+    check [REQUIREMENT][README.BADGES] ... PASSED
 
 Running check [RECOMMENDATION][README.LIBRARY_STATUS] ...
-	check [RECOMMENDATION][README.LIBRARY_STATUS] ... PASSED
+    check [RECOMMENDATION][README.LIBRARY_STATUS] ... PASSED
 
 Running check [RECOMMENDATION][DIRECTORY.SOURCES] ...
 [WARNING        ][DIRECTORY.SOURCES        ]: The directory '/Users/dariusn/dev/dn/git/Beman/exemplar/src/beman/exemplar' does not exist.
-	check [RECOMMENDATION][DIRECTORY.SOURCES] ... FAILED
+    check [RECOMMENDATION][DIRECTORY.SOURCES] ... FAILED
 
 
 beman-tidy pipeline finished.
@@ -120,21 +122,22 @@ Coverage    REQUIREMENT: 100.0% (1/1 checks passed).
 Coverage RECOMMENDATION: 66.67% (2/3 checks passed).
 ```
 
+```shell
 # dry-run, require-all, verbose mode - no errors
 $ uv run beman-tidy /path/to/exemplar --require-all --verbose
 beman-tidy pipeline started ...
 
 Running check [RECOMMENDATION][README.TITLE] ...
-	check [RECOMMENDATION][README.TITLE] ... PASSED
+    check [RECOMMENDATION][README.TITLE] ... PASSED
 
 Running check [REQUIREMENT][README.BADGES] ...
-	check [REQUIREMENT][README.BADGES] ... PASSED
+    check [REQUIREMENT][README.BADGES] ... PASSED
 
 Running check [RECOMMENDATION][README.LIBRARY_STATUS] ...
-	check [RECOMMENDATION][README.LIBRARY_STATUS] ... PASSED
+    check [RECOMMENDATION][README.LIBRARY_STATUS] ... PASSED
 
 Running check [RECOMMENDATION][DIRECTORY.SOURCES] ...
-	check [RECOMMENDATION][DIRECTORY.SOURCES] ... PASSED
+    check [RECOMMENDATION][DIRECTORY.SOURCES] ... PASSED
 
 
 beman-tidy pipeline finished.
@@ -146,10 +149,10 @@ Coverage    REQUIREMENT: 100.0% (1/1 checks passed).
 Coverage RECOMMENDATION: 100.0% (3/3 checks passed).
 ```
 
-* Run beman-tidy on the exemplar repository (fix issues in-place):
+- Run beman-tidy on the exemplar repository (fix issues in-place):
 
 ```shell
-$ uv run beman-tidy path/to/exemplar --fix-inplace --verbose
+uv run beman-tidy path/to/exemplar --fix-inplace --verbose
 ```
 
 ## beman-tidy Development

--- a/tools/beman-tidy/beman_tidy/lib/pipeline.py
+++ b/tools/beman-tidy/beman_tidy/lib/pipeline.py
@@ -73,7 +73,7 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
 
         implemented_checks = get_registered_beman_standard_checks()
         all_checks = beman_standard_check_config
-        
+
         cnt_passed = {
             "REQUIREMENT": 0,
             "RECOMMENDATION": 0,

--- a/tools/beman-tidy/docs/dev-guide.md
+++ b/tools/beman-tidy/docs/dev-guide.md
@@ -10,6 +10,7 @@ Expected Development Flow:
 * Commit the changes.
 
 Requirements:
+
 * `beman-tidy` must be able to run on Windows, Linux, and macOS, thus it's 100% Python.
 * `beman-tidy` must NOT use internet access.  A local snapshot of the standard is used (check `.beman-standard.yml`).
 * `beman-tidy` must have `verbose` and `non-verbose` modes. Default is `non-verbose`.
@@ -17,39 +18,47 @@ Requirements:
 * `beman-tidy` must detect types of checks: failed, passed, skipped (not implemented) and print the summary/coverage.
 
 Limitations:
+
 * `2025-06-07`: `beman-tidy` will not support the `--fix-inplace` flag in the first iteration for most of the checks.
-* `2025-06-07`: `beman-tidy` may generate small changes to the standard (e.g., for automated fixes), while the standard is not stable. Thus, the tool itself may be unstable.
+* `2025-06-07`: `beman-tidy` may generate small changes to the standard (e.g., for automated fixes), while the standard
+  is not stable. Thus, the tool itself may be unstable.
 
 ## Tree structure
 
 * `README.md`: The public documentation for the `beman-tidy` tool.
 * `docs/`: The internal documentation.
 * `beman_tidy/`: The package/production code for the tool.
-   * `beman_tidy/cli.py`: The CLI / entry point for the tool.
-   * `beman_tidy/lib/`: The library for the tool.
-      * `beman_tidy/lib/checks/`: The checks for the tool.
-      * `beman_tidy/lib/pipeline.py`: The checks pipeline for the `beman-tidy` tool.
-   * `beman_tidy/.beman-standard.yml`: Stable (offline)version of the standard.
+  * `beman_tidy/cli.py`: The CLI / entry point for the tool.
+  * `beman_tidy/lib/`: The library for the tool.
+    * `beman_tidy/lib/checks/`: The checks for the tool.
+    * `beman_tidy/lib/pipeline.py`: The checks pipeline for the `beman-tidy` tool.
+  * `beman_tidy/.beman-standard.yml`: Stable (offline)version of the standard.
 * `tests/`: Unit tests for the tool.
-   * Structure is similar to the `beman_tidy/` directory.
-   * `pytest` is used for testing.
+  * Structure is similar to the `beman_tidy/` directory.
+  * `pytest` is used for testing.
 
 ## Adding a new check
 
 * `[mandatory]` Make sure `beman_tidy/.beman-standard.yml` reflects your check metadata (latest status from [BEMAN_STANDARD.md](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md).
-  * `[optional]` New syntax / keys from yml config can be added in [infra/tools/beman-tidy/beman_tidy/lib/utils
-/git.py:load_beman_standard_config()](https://github.com/bemanproject/infra/blob/main/tools/beman-tidy/beman_tidy/lib/utils/git.py#L68) if not already implemented. Checks for TODOs in `load_beman_standard_config()`.
+  * `[optional]` New syntax / keys from yml config can be added in
+    [infra/tools/beman-tidy/beman_tidy/lib/utils_git.py:load_beman_standard_config()](https://github.com/bemanproject/infra/blob/main/tools/beman-tidy/beman_tidy/lib/utils/git.py#L68)
+    if not already implemented. Checks for TODOs in `load_beman_standard_config()`.
 * `[mandatory]` Add the check to the `beman_tidy/lib/checks/beman_standard/` directory.
-   *  `[mandatory]` E.g., `README.*` checks will most likely go to a path similar to `beman_tidy/lib/checks/beman_standard/readme.py`.
-   *  `[mandatory]` Use an appropiate base class - e.g., defaults like `FileBaseCheck` / `DirectoryBaseCheck` or create specializations for reusing code - e.g.,  `ReadmeBaseCheck(FileBaseCheck)` / `CmakeBaseCheck(FileBaseCheck)` / `CppBaseCheck(FileBaseCheck)` etc.
-   *  `[mandatory]` Register the new check via `@register_beman_standard_check` decorator - e.g.,
-     ```python
-     @register_beman_standard_check("README.TITLE")
-     class ReadmeTitleCheck(ReadmeBaseCheck):
-     ```
-* `[mandatory]` Import the check to the `beman_tidy/lib/pipeline.py` file (e.g., `from .checks.beman_standard.readme import ReadmeTitleCheck`).
+  * `[mandatory]` E.g., `README.*` checks will most likely go to a path similar to `beman_tidy/lib/checks/beman_standard/readme.py`.
+  * `[mandatory]` Use an appropriate base class - e.g., defaults like `FileBaseCheck` / `DirectoryBaseCheck` or create
+    specializations for reusing code - e.g.,  `ReadmeBaseCheck(FileBaseCheck)` / `CmakeBaseCheck(FileBaseCheck)` /
+    `CppBaseCheck(FileBaseCheck)` etc.
+  * `[mandatory]` Register the new check via `@register_beman_standard_check` decorator - e.g.,
+
+    ```python
+    @register_beman_standard_check("README.TITLE")
+    class ReadmeTitleCheck(ReadmeBaseCheck):
+    ```
+
+* `[mandatory]` Import the check to the `beman_tidy/lib/pipeline.py` file (e.g.,
+  `from .checks.beman_standard.readme import ReadmeTitleCheck`).
 * `[mandatory]` Add tests for the check to the `tests/beman_standard/` directory. More in [Writing Tests](#writing-tests).
-* `[optional]` Updates docs if needed in `README.md` and `docs/dev-guide.md` files. 
+* `[optional]` Updates docs if needed in `README.md` and `docs/dev-guide.md` files.
 * `[optional]` Update the `beman_tidy/cli.py` file if the public API has changed.
 
 Check this PR example: [beman-tidy: add check - README.LIBRARY_STATUS](https://github.com/bemanproject/infra/pull/35).
@@ -59,8 +68,8 @@ Check this PR example: [beman-tidy: add check - README.LIBRARY_STATUS](https://g
 Run the linter on the beman-tidy's codebase:
 
 ```shell
-$ uv run ruff check --diff
-$ uv run ruff check --fix
+uv run ruff check --diff
+uv run ruff check --fix
 ```
 
 ## Testing
@@ -90,23 +99,30 @@ tests/beman_standard/readme/test_readme.py::test__README_BADGES__fix_invalid SKI
 
 ### Writing Tests
 
-* `tests/lib/checks/beman_standard/<check_category>/test_<check_category>.py`: The test file for the `<check_category>` check.
+* `tests/lib/checks/beman_standard/<check_category>/test_<check_category>.py`: The test file for the `<check_category>`
+  check.
   * e.g., for `check_category = "readme"` the test file is `tests/lib/checks/beman_standard/readme/test_readme.py`.
 * `test__<check_category>__<test_case_name>()` function inside the test file.
   * e.g., for `check_category = "readme"` and `test_case_name = "valid"` the function is `test__README_TITLE__valid()`.
-  * e.g., for `check_category = "readme"` and `test_case_name = "invalid"` the function is `test__README_TITLE__invalid()`.
+  * e.g., for `check_category = "readme"` and `test_case_name = "invalid"` the function is
+    `test__README_TITLE__invalid()`.
 * `tests/beman_standard/<check_category>/data/`: The data for the tests (e.g., files, directories, etc.).
-  * e.g., for `check_category = "readme"` and `test_case_name = "valid"` the data is in `tests/lib/checks/beman_standard/readme/data/valid/`.
-  * e.g., for `check_category = "readme"` and `test_case_name = "invalid"` the data is in `tests/lib/checks/beman_standard/readme/data/invalid/`.
-  * e.g., for `check_category = "readme"` and `test_case_name = "fix_invalid"` the data may use both `valid` and `invalid` files. It is recommended to not change these files and use temporary copies having suffix `.delete_me` (which are not tracked by git).
+  * e.g., for `check_category = "readme"` and `test_case_name = "valid"` the data is in
+    `tests/lib/checks/beman_standard/readme/data/valid/`.
+  * e.g., for `check_category = "readme"` and `test_case_name = "invalid"` the data is in
+    `tests/lib/checks/beman_standard/readme/data/invalid/`.
+  * e.g., for `check_category = "readme"` and `test_case_name = "fix_invalid"` the data may use both `valid` and
+    `invalid` files. It is recommended to not change these files and use temporary copies having suffix `.delete_me`
+    (which are not tracked by git).
 * Default setup / mocks:
   * `repo_info`: The repository information (e.g., path, name, etc.). Mocked with hardcoded values of `beman.exemplar`.
-  * `beman_standard_check_config`: The Beman Standard configuration file. Actual load of the `.beman-standard.yml` file.
+  * `beman_standard_check_config`: The Beman Standard configuration file. Actual load of the `.beman-standard.yml`
+    file.
 * Always add at least 3 test cases for each check.
   * `valid`: The test case for the valid case.
   * `invalid`: The test case for the invalid case.
-  * `fix_invalid`: The test case for the fix invalid case. If the fix is not (yet) implementable, add a `@pytest.mark.skip(reason="NOT implemented")` decorator to track the progress.
-
+  * `fix_invalid`: The test case for the fix invalid case. If the fix is not (yet) implementable, add a
+    `@pytest.mark.skip(reason="NOT implemented")` decorator to track the progress.
 
 ## Changing dependencies
 

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v1.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v1.md
@@ -5,12 +5,12 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library typo Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
+<!-- markdownlint-disable-next-line line-length -->
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-
 This is NOT a valid README.md according to the Beman Standard: typos in badges.
-

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v2.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v2.md
@@ -5,13 +5,11 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Other display text](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-
 This is NOT a valid README.md according to the Beman Standard: invalid badge display text.
-
-

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v3.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v3.md
@@ -5,12 +5,11 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/mylogo) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-
 This is NOT a valid README.md according to the Beman Standard: invalid badge URL.
-

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-status-line-v1.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-status-line-v1.md
@@ -1,10 +1,11 @@
-## beman.exemplar: A Beman Library Exemplar
+# beman.exemplar: A Beman Library Exemplar
 
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-status-line-v2.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-status-line-v2.md
@@ -5,11 +5,12 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
+<!-- markdownlint-disable-next-line line-length no-bare-urls -->
 **Status**: [under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md# TYPO HERE under-development-and-not-yet-ready-for-production-use)
 
 This is NOT a valid README.md according to the Beman Standard: the library status line has typos.
-

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-status-line-v3.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-status-line-v3.md
@@ -5,6 +5,7 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
@@ -15,4 +16,3 @@
 **Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed),
 
 This is NOT a valid README.md according to the Beman Standard: the library status is duplicated.
-

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-title-v1.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-title-v1.md
@@ -5,11 +5,11 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
-
 
 This is NOT a valid README.md according to the Beman Standard: missing beman.exemplar.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-title-v2.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-title-v2.md
@@ -5,12 +5,11 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-
 This is NOT a valid README.md according to the Beman Standard: missing :
-

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-title-v3.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-title-v3.md
@@ -5,12 +5,12 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
+<!-- markdownlint-disable-next-line line-length -->
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-
 This is NOT a valid README.md according to the Beman Standard: wrong library name.
-

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-title-v4.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-title-v4.md
@@ -5,12 +5,11 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-
 This is NOT a valid README.md according to the Beman Standard: wrong library name.
-

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v1.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v1.md
@@ -5,13 +5,14 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-
+<!-- markdownlint-disable-next-line line-length -->
 This is a valid README.md file that follows the Beman Standard: the title is properly formatted with the library name and a short description.
 
 This is a valid README.md file that follows the Beman Standard: the badges are properly formatted.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v2.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v2.md
@@ -5,12 +5,14 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
 **Status**: [Production ready. API may undergo changes.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-api-may-undergo-changes)
 
+<!-- markdownlint-disable-next-line line-length -->
 This is a valid README.md file that follows the Beman Standard: the title is properly formatted with the library name and a short description.
 
 This is a valid README.md file that follows the Beman Standard: the badges are properly formatted.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v3.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v3.md
@@ -5,12 +5,15 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
+<!-- markdownlint-disable-next-line line-length -->
 **Status**: [Production ready. Stable API.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#production-ready-stable-api)
 
+<!-- markdownlint-disable-next-line line-length -->
 This is a valid README.md file that follows the Beman Standard: the title is properly formatted with the library name and a short description.
 
 This is a valid README.md file that follows the Beman Standard: the badges are properly formatted.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v4.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v4.md
@@ -5,12 +5,14 @@
 <!-- markdownlint-disable-next-line line-length -->
 ![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
+<!-- markdownlint-disable-next-line line-length -->
 **Purpose**: `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
 **Status**: [Retired. No longer maintained or actively developed.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#retired-no-longer-maintained-or-actively-developed)
 
+<!-- markdownlint-disable-next-line line-length -->
 This is a valid README.md file that follows the Beman Standard: the title is properly formatted with the library name and a short description.
 
 This is a valid README.md file that follows the Beman Standard: the badges are properly formatted.


### PR DESCRIPTION
Previously, although infra provided beman-tidy as a pre-commit hook to consumers of the repository, it did not use pre-commit checks on its own source.

This commit addresses this by adding all of the same pre-commit checks as are used in exemplar, except for clang-format and CMake linting, since those aren't relevant here.

It fixes all of the failed checks and adds pre-commit checking to CI so they don't recur.