### PR TITLE
Fix duplicative CI runs when updating a pull request

### DIFF
--- a/.github/workflows/beman-submodule.yml
+++ b/.github/workflows/beman-submodule.yml
@@ -4,6 +4,8 @@ name: beman-submodule tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/beman-tidy.yml
+++ b/.github/workflows/beman-tidy.yml
@@ -4,6 +4,8 @@ name: beman-tidy tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
When updating the branch associated with a pull request, previously, CI would trigger twice: once for the update to the branch, and another time for the update to the pull request itself.

This commit addresses the issue by restricting CI runs for updates to branches to those that update the main branch itself.