### PR TITLE
[beman-tidy] general cleanup

### DIFF
--- a/tools/beman-tidy/beman_tidy/cli.py
+++ b/tools/beman-tidy/beman_tidy/cli.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse

--- a/tools/beman-tidy/beman_tidy/cli.py
+++ b/tools/beman-tidy/beman_tidy/cli.py
@@ -62,7 +62,8 @@ def main():
     )
 
     failed_checks = run_checks_pipeline(
-        checks_to_run, args, beman_standard_check_config)
+        checks_to_run, args, beman_standard_check_config
+    )
     sys.exit(failed_checks)
 
 

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/base_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from abc import ABC, abstractmethod

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/base_check.py
@@ -20,24 +20,30 @@ class BaseCheck(ABC):
         """
 
         # check name -  e.g. "README.TITLE"
-        self.name = name if name is not None else get_beman_standard_check_name_by_class(
-            self.__class__)
-        assert self.name is not None, f"Check name not found for class: {self.__class__.__name__}"
+        self.name = (
+            name
+            if name is not None
+            else get_beman_standard_check_name_by_class(self.__class__)
+        )
+        assert self.name is not None, (
+            f"Check name not found for class: {self.__class__.__name__}"
+        )
 
         # save the check config
         self.config = beman_standard_check_config[self.name]
 
         # set type - e.g. "REQUIREMENT" or "RECOMMENDATION"
         self.type = beman_standard_check_config[self.name]["type"]
-        assert self.type in [
-            'REQUIREMENT', 'RECOMMENDATION'], f"Invalid check type: {self.type} for check = {self.name}."
+        assert self.type in ["REQUIREMENT", "RECOMMENDATION"], (
+            f"Invalid check type: {self.type} for check = {self.name}."
+        )
 
         # set full text body - e.g. "The README.md should begin ..."
         self.full_text_body = beman_standard_check_config[self.name]["full_text_body"]
         assert self.full_text_body is not None
 
         # set log level - e.g. "ERROR" or "WARNING"
-        self.log_level = 'ERROR' if self.type == 'REQUIREMENT' else 'WARNING'
+        self.log_level = "ERROR" if self.type == "REQUIREMENT" else "WARNING"
         self.log_enabled = False
 
         # set repo info
@@ -51,7 +57,9 @@ class BaseCheck(ABC):
         assert self.library_name is not None
 
         # set beman library maturity model
-        beman_library_maturity_model = beman_standard_check_config["README.LIBRARY_STATUS"]
+        beman_library_maturity_model = beman_standard_check_config[
+            "README.LIBRARY_STATUS"
+        ]
         assert "values" in beman_library_maturity_model
         assert len(beman_library_maturity_model["values"]) == 4
         self.beman_library_maturity_model = beman_library_maturity_model["values"]
@@ -108,4 +116,4 @@ class BaseCheck(ABC):
         """
 
         if self.log_enabled and enabled:
-            print(f'[{self.log_level:<15}][{self.name:<25}]: {message}')
+            print(f"[{self.log_level:<15}][{self.name:<25}]: {message}")

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/directory_base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/directory_base_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from abc import abstractmethod

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/directory_base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/directory_base_check.py
@@ -14,7 +14,6 @@ class DirectoryBaseCheck(BaseCheck):
 
     def __init__(self, repo_info, beman_standard_check_config, relative_path):
         super().__init__(repo_info, beman_standard_check_config)
-        print(repo_info)
 
         # set path - e.g. "src/beman/exemplar"
         self.path = self.repo_path / relative_path

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/file_base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/file_base_check.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from abc import abstractmethod

--- a/tools/beman-tidy/beman_tidy/lib/checks/base/file_base_check.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/base/file_base_check.py
@@ -59,7 +59,7 @@ class FileBaseCheck(BaseCheck):
         Read the file content.
         """
         try:
-            with open(self.path, 'r') as file:
+            with open(self.path, "r") as file:
                 return file.read()
         except Exception:
             return ""
@@ -69,7 +69,7 @@ class FileBaseCheck(BaseCheck):
         Read the file content as lines.
         """
         try:
-            with open(self.path, 'r') as file:
+            with open(self.path, "r") as file:
                 return file.readlines()
         except Exception:
             return []
@@ -85,7 +85,7 @@ class FileBaseCheck(BaseCheck):
         Write the content to the file.
         """
         try:
-            with open(self.path, 'w') as file:
+            with open(self.path, "w") as file:
                 file.write(content)
         except Exception as e:
             self.log(f"Error writing the file '{self.path}': {e}")

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/cmake.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/cmake.py
@@ -13,6 +13,7 @@ class CMakeBaseCheck(FileBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
         super().__init__(repo_info, beman_standard_check_config, "CMakeLists.txt")
 
+
 # TODO CMAKE.DEFAULT
 
 

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/cmake.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/cmake.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ..base.file_base_check import FileBaseCheck

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/cpp.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/cpp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # [CPP.*] checks category.

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/directory.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/directory.py
@@ -4,6 +4,7 @@
 from ..base.directory_base_check import DirectoryBaseCheck
 from ..system.registry import register_beman_standard_check
 
+
 # [DIRECTORY.*] checks category.
 class BemanTreeDirectoryCheck(DirectoryBaseCheck):
     """
@@ -11,7 +12,11 @@ class BemanTreeDirectoryCheck(DirectoryBaseCheck):
     """
 
     def __init__(self, repo_info, beman_standard_check_config, prefix_path):
-        super().__init__(repo_info, beman_standard_check_config, f"{prefix_path}/beman/{repo_info['name']}")
+        super().__init__(
+            repo_info,
+            beman_standard_check_config,
+            f"{prefix_path}/beman/{repo_info['name']}",
+        )
 
 
 # TODO DIRECTORY.INTERFACE_HEADERS
@@ -26,6 +31,7 @@ class DirectorySourcesCheck(BemanTreeDirectoryCheck):
     """
     Check if the sources directory is src/beman/<short_name>.
     """
+
     def __init__(self, repo_info, beman_standard_check_config):
         super().__init__(repo_info, beman_standard_check_config, "src")
 

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/directory.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/directory.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ..base.directory_base_check import DirectoryBaseCheck

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/file.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/file.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # [FILE.*] checks category.

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/general.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/general.py
@@ -1,5 +1,4 @@
-
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # TODO LIBRARY.NAMES

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
@@ -13,6 +13,7 @@ class LicenseBaseCheck(FileBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
         super().__init__(repo_info, beman_standard_check_config, "LICENSE")
 
+
 # TODO LICENSE.APPROVED
 
 

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from ..base.file_base_check import FileBaseCheck

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import re

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
@@ -30,7 +30,8 @@ class ReadmeTitleCheck(ReadmeBaseCheck):
         regex = rf"^# {re.escape(self.library_name)}: (.*)$"  # noqa: F541
         if not re.match(regex, first_line):
             self.log(
-                f"The first line of the file '{self.path}' is invalid. It should start with '# {self.library_name}: <short_description>'.")
+                f"The first line of the file '{self.path}' is invalid. It should start with '# {self.library_name}: <short_description>'."
+            )
             return False
 
         return True
@@ -57,11 +58,11 @@ class ReadmeBadgesCheck(ReadmeBaseCheck):
         assert len(badges) == 4  # The number of library maturity model states
 
         # Check if exactly one of the required badges is present.
-        badge_count = len(
-            [badge for badge in badges if self.has_content(badge)])
+        badge_count = len([badge for badge in badges if self.has_content(badge)])
         if badge_count != 1:
             self.log(
-                f"The file '{self.path}' does not contain exactly one of the required badges from {badges}")
+                f"The file '{self.path}' does not contain exactly one of the required badges from {badges}"
+            )
             return False
 
         return True
@@ -69,6 +70,7 @@ class ReadmeBadgesCheck(ReadmeBaseCheck):
     def fix(self):
         # TODO: Implement the fix.
         pass
+
 
 # TODO README.PURPOSE
 
@@ -89,11 +91,11 @@ class ReadmeLibraryStatusCheck(ReadmeBaseCheck):
         assert len(statuses) == len(self.beman_library_maturity_model)
 
         # Check if at least one of the required status values is present.
-        status_count = len(
-            [status for status in statuses if self.has_content(status)])
+        status_count = len([status for status in statuses if self.has_content(status)])
         if status_count != 1:
             self.log(
-                f"The file '{self.path}' does not contain exactly one of the required statuses from {statuses}")
+                f"The file '{self.path}' does not contain exactly one of the required statuses from {statuses}"
+            )
             return False
 
         return True

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/release.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # [RELEASE.*] checks category.

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-from ..base.base_check import BaseCheck
+from .cmake import CMakeBaseCheck
 from ..system.registry import register_beman_standard_check
 
 # [TOPLEVEL.*] checks category.
@@ -10,42 +10,19 @@ from ..system.registry import register_beman_standard_check
 # Note: ToplevelBaseCheck is not a registered check!
 
 
-class ToplevelBaseCheck(BaseCheck):
-    def __init__(self, repo_info, beman_standard_check_config):
-        super().__init__(repo_info, beman_standard_check_config)
-
-@register_beman_standard_check("TOPLEVEL.CMAKE")
-class ToplevelCmakeCheck(ToplevelBaseCheck):
+@register_beman_standard_check(check="TOPLEVEL.CMAKE")
+class ToplevelCmakeCheck(CMakeBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
         super().__init__(repo_info, beman_standard_check_config)
 
     def check(self):
-        """
-        self.config["value"] contains the CMake file name.
-        """
-        self.path = self.repo_path / self.config["value"]
-        assert self.config["value"].endswith(".txt")
-
-        if not self.path.exists():
-            self.log("The top-level CMake file does not exist.")
-            return False
-
-        try:
-            with open(self.path, 'r') as file:
-                if len(file.read()) == 0:
-                    self.log("The top-level CMake file is empty.")
-                    return False
-        except Exception:
-            self.log("Failed to read the top-level CMake file.")
-            return False
-
-        return True
+        return super().pre_check()
 
     def fix(self):
         # TODO: Implement the fix.
         pass
 
-# TODO TOPLEVEL.LICENSE - use FileBaseCheck
 
+# TODO TOPLEVEL.LICENSE - use FileBaseCheck
 
 # TODO TOPLEVEL.README - use ReadmeBaseCheck

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/toplevel.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from .cmake import CMakeBaseCheck

--- a/tools/beman-tidy/beman_tidy/lib/checks/system/git.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/system/git.py
@@ -12,8 +12,7 @@ class DisallowFixInplaceAndUnstagedChangesCheck(BaseCheck):
     """
 
     def __init__(self, repo_info, beman_standard_check_config):
-        super().__init__(repo_info, beman_standard_check_config,
-                         'NO_UNSTAGED_CHANGES')
+        super().__init__(repo_info, beman_standard_check_config, "NO_UNSTAGED_CHANGES")
 
     def check(self):
         """
@@ -26,5 +25,6 @@ class DisallowFixInplaceAndUnstagedChangesCheck(BaseCheck):
         Stop the program if there are unstaged changes.
         """
         self.log(
-            "The fix cannot be applied inplace. Please commit or stash your changes. STOP.")
+            "The fix cannot be applied inplace. Please commit or stash your changes. STOP."
+        )
         sys.exit(1)

--- a/tools/beman-tidy/beman_tidy/lib/checks/system/git.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/system/git.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import sys

--- a/tools/beman-tidy/beman_tidy/lib/checks/system/registry.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/system/registry.py
@@ -19,9 +19,11 @@ def register_beman_standard_check(check: str):
     Notes: Only register most derived check classes, which are actually part from
     The Beman Standard - e.g., README.TITLE, README.BADGES, etc.
     """
+
     def decorator(check_class: Type) -> Type:
         _beman_standard_check_registry[check] = check_class
         return check_class
+
     return decorator
 
 

--- a/tools/beman-tidy/beman_tidy/lib/checks/system/registry.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/system/registry.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from typing import Dict, Type, List

--- a/tools/beman-tidy/beman_tidy/lib/pipeline.py
+++ b/tools/beman-tidy/beman_tidy/lib/pipeline.py
@@ -36,6 +36,7 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
     """
     Helper function to log messages.
     """
+
     def log(msg):
         if args.verbose:
             print(msg)
@@ -46,30 +47,35 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
     @param log_enabled: Whether to log the check result.
     @return: True if the check passed, False otherwise.
     """
+
     def run_check(check_class, log_enabled=args.verbose):
-        check_instance = check_class(
-            args.repo_info, beman_standard_check_config)
+        check_instance = check_class(args.repo_info, beman_standard_check_config)
         check_instance.log_enabled = log_enabled
         check_type = check_instance.type
 
-        log(
-            f"Running check [{check_instance.type}][{check_instance.name}] ... ")
+        log(f"Running check [{check_instance.type}][{check_instance.name}] ... ")
 
-        if (check_instance.pre_check() and check_instance.check()) or (args.fix_inplace and check_instance.fix()):
-            log(f"\tcheck [{check_instance.type}][{check_instance.name}] ... {green_color}PASSED{no_color}\n")
+        if (check_instance.pre_check() and check_instance.check()) or (
+            args.fix_inplace and check_instance.fix()
+        ):
+            log(
+                f"\tcheck [{check_instance.type}][{check_instance.name}] ... {green_color}PASSED{no_color}\n"
+            )
             return check_type, True
         else:
-            log(f"\tcheck [{check_instance.type}][{check_instance.name}] ... {red_color}FAILED{no_color}\n")
+            log(
+                f"\tcheck [{check_instance.type}][{check_instance.name}] ... {red_color}FAILED{no_color}\n"
+            )
             return check_type, False
 
     """
     Main pipeline.
     """
+
     def run_pipeline_helper():
         # Internal checks
         if args.fix_inplace:
-            run_check(DisallowFixInplaceAndUnstagedChangesCheck,
-                      log_enabled=False)
+            run_check(DisallowFixInplaceAndUnstagedChangesCheck, log_enabled=False)
 
         implemented_checks = get_registered_beman_standard_checks()
         all_checks = beman_standard_check_config
@@ -113,32 +119,59 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
             else:
                 cnt_implemented_checks[check_type] += 1
 
-        return cnt_passed, cnt_failed, cnt_skipped, cnt_implemented_checks, cnt_all_beman_standard_checks
+        return (
+            cnt_passed,
+            cnt_failed,
+            cnt_skipped,
+            cnt_implemented_checks,
+            cnt_all_beman_standard_checks,
+        )
 
     log("beman-tidy pipeline started ...\n")
-    cnt_passed, cnt_failed, cnt_skipped, cnt_implemented_checks, cnt_all_beman_standard_checks = run_pipeline_helper()
+    (
+        cnt_passed,
+        cnt_failed,
+        cnt_skipped,
+        cnt_implemented_checks,
+        cnt_all_beman_standard_checks,
+    ) = run_pipeline_helper()
     log("\nbeman-tidy pipeline finished.\n")
 
     # Always print the summary.
-    print(f"Summary    REQUIREMENT: {green_color} {cnt_passed['REQUIREMENT']} checks PASSED{no_color}, {red_color}{cnt_failed['REQUIREMENT']} checks FAILED{no_color}, {gray_color}{cnt_skipped['REQUIREMENT']} skipped (NOT implemented).{no_color}")
-    print(f"Summary RECOMMENDATION: {green_color} {cnt_passed['RECOMMENDATION']} checks PASSED{no_color}, {red_color}{cnt_failed['RECOMMENDATION']} checks FAILED{no_color}, {gray_color}{cnt_skipped['RECOMMENDATION']} skipped (NOT implemented).{no_color}")
+    print(
+        f"Summary    REQUIREMENT: {green_color} {cnt_passed['REQUIREMENT']} checks PASSED{no_color}, {red_color}{cnt_failed['REQUIREMENT']} checks FAILED{no_color}, {gray_color}{cnt_skipped['REQUIREMENT']} skipped (NOT implemented).{no_color}"
+    )
+    print(
+        f"Summary RECOMMENDATION: {green_color} {cnt_passed['RECOMMENDATION']} checks PASSED{no_color}, {red_color}{cnt_failed['RECOMMENDATION']} checks FAILED{no_color}, {gray_color}{cnt_skipped['RECOMMENDATION']} skipped (NOT implemented).{no_color}"
+    )
 
     # Always print the coverage.
-    coverage_requirement = round(cnt_passed['REQUIREMENT'] / cnt_implemented_checks['REQUIREMENT'] * 100, 2)
-    coverage_recommendation = round(cnt_passed['RECOMMENDATION'] / cnt_implemented_checks['RECOMMENDATION'] * 100, 2)
-    total_passed = cnt_passed['REQUIREMENT'] + cnt_passed['RECOMMENDATION']
-    total_implemented = cnt_implemented_checks['REQUIREMENT'] + cnt_implemented_checks['RECOMMENDATION']
+    coverage_requirement = round(
+        cnt_passed["REQUIREMENT"] / cnt_implemented_checks["REQUIREMENT"] * 100, 2
+    )
+    coverage_recommendation = round(
+        cnt_passed["RECOMMENDATION"] / cnt_implemented_checks["RECOMMENDATION"] * 100, 2
+    )
+    total_passed = cnt_passed["REQUIREMENT"] + cnt_passed["RECOMMENDATION"]
+    total_implemented = (
+        cnt_implemented_checks["REQUIREMENT"] + cnt_implemented_checks["RECOMMENDATION"]
+    )
     total_coverage = round((total_passed) / (total_implemented) * 100, 2)
     print(
-        f"\n{__calculate_coverage_color(coverage_requirement)}Coverage    REQUIREMENT: {coverage_requirement:{6}.2f}% ({cnt_passed['REQUIREMENT']}/{cnt_implemented_checks['REQUIREMENT']} checks passed).{no_color}")
+        f"\n{__calculate_coverage_color(coverage_requirement)}Coverage    REQUIREMENT: {coverage_requirement:{6}.2f}% ({cnt_passed['REQUIREMENT']}/{cnt_implemented_checks['REQUIREMENT']} checks passed).{no_color}"
+    )
     if args.require_all:
         print(
-            f"{__calculate_coverage_color(coverage_recommendation)}Coverage RECOMMENDATION: {coverage_recommendation:{6}.2f}% ({cnt_passed['RECOMMENDATION']}/{cnt_implemented_checks['RECOMMENDATION']} checks passed).{no_color}")
+            f"{__calculate_coverage_color(coverage_recommendation)}Coverage RECOMMENDATION: {coverage_recommendation:{6}.2f}% ({cnt_passed['RECOMMENDATION']}/{cnt_implemented_checks['RECOMMENDATION']} checks passed).{no_color}"
+        )
         print(
-            f"{__calculate_coverage_color(total_coverage)}Coverage          TOTAL: {total_coverage:{6}.2f}% ({total_passed}/{total_implemented} checks passed).{no_color}")
+            f"{__calculate_coverage_color(total_coverage)}Coverage          TOTAL: {total_coverage:{6}.2f}% ({total_passed}/{total_implemented} checks passed).{no_color}"
+        )
     else:
         print("Note: RECOMMENDATIONs are not included (--require-all NOT set).")
-    total_cnt_failed = cnt_failed['REQUIREMENT'] + (cnt_failed['RECOMMENDATION'] if args.require_all else 0)
+    total_cnt_failed = cnt_failed["REQUIREMENT"] + (
+        cnt_failed["RECOMMENDATION"] if args.require_all else 0
+    )
 
     sys.stdout.flush()
     return total_cnt_failed

--- a/tools/beman-tidy/beman_tidy/lib/pipeline.py
+++ b/tools/beman-tidy/beman_tidy/lib/pipeline.py
@@ -126,16 +126,34 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
     # Always print the coverage.
     coverage_requirement = round(cnt_passed['REQUIREMENT'] / cnt_implemented_checks['REQUIREMENT'] * 100, 2)
     coverage_recommendation = round(cnt_passed['RECOMMENDATION'] / cnt_implemented_checks['RECOMMENDATION'] * 100, 2)
-    total_coverage = round((cnt_passed['REQUIREMENT'] + cnt_passed['RECOMMENDATION']) / (cnt_implemented_checks['REQUIREMENT'] + cnt_implemented_checks['RECOMMENDATION']) * 100, 2)
+    total_passed = cnt_passed['REQUIREMENT'] + cnt_passed['RECOMMENDATION']
+    total_implemented = cnt_implemented_checks['REQUIREMENT'] + cnt_implemented_checks['RECOMMENDATION']
+    total_coverage = round((total_passed) / (total_implemented) * 100, 2)
     print(
-        f"\n{green_color if coverage_requirement == 100 else red_color}Coverage    REQUIREMENT: {coverage_requirement}% ({cnt_passed['REQUIREMENT']}/{cnt_implemented_checks['REQUIREMENT']} checks passed).{no_color}")
+        f"\n{__calculate_coverage_color(coverage_requirement)}Coverage    REQUIREMENT: {coverage_requirement:{6}.2f}% ({cnt_passed['REQUIREMENT']}/{cnt_implemented_checks['REQUIREMENT']} checks passed).{no_color}")
     if args.require_all:
         print(
-            f"{green_color if coverage_recommendation == 100 else red_color}Coverage RECOMMENDATION: {coverage_recommendation}% ({cnt_passed['RECOMMENDATION']}/{cnt_implemented_checks['RECOMMENDATION']} checks passed).{no_color}")
+            f"{__calculate_coverage_color(coverage_recommendation)}Coverage RECOMMENDATION: {coverage_recommendation:{6}.2f}% ({cnt_passed['RECOMMENDATION']}/{cnt_implemented_checks['RECOMMENDATION']} checks passed).{no_color}")
+        print(
+            f"{__calculate_coverage_color(total_coverage)}Coverage          TOTAL: {total_coverage:{6}.2f}% ({total_passed}/{total_implemented} checks passed).{no_color}")
     else:
         print("Note: RECOMMENDATIONs are not included (--require-all NOT set).")
     total_cnt_failed = cnt_failed['REQUIREMENT'] + (cnt_failed['RECOMMENDATION'] if args.require_all else 0)
 
-
     sys.stdout.flush()
     return total_cnt_failed
+
+
+def __calculate_coverage_color(cov):
+    """
+    Returns the colour for the coverage print based on severity
+    Green for 100%
+    Red for 0%
+    Yellow for anything else
+    """
+    if cov == 100:
+        return green_color
+    elif cov == 0:
+        return red_color
+    else:
+        return yellow_color

--- a/tools/beman-tidy/beman_tidy/lib/pipeline.py
+++ b/tools/beman-tidy/beman_tidy/lib/pipeline.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import sys

--- a/tools/beman-tidy/beman_tidy/lib/utils/git.py
+++ b/tools/beman-tidy/beman_tidy/lib/utils/git.py
@@ -55,8 +55,7 @@ def get_repo_info(path: str):
         print(f"The path '{path}' is not inside a valid Git repository.")
         sys.exit(1)
     except Exception:
-        print(
-            f"An error occurred while getting repository information. Check {path}.")
+        print(f"An error occurred while getting repository information. Check {path}.")
         sys.exit(1)
 
 
@@ -115,8 +114,7 @@ def load_beman_standard_config(path=get_beman_standard_config_path()):
             elif "default_group" in entry:
                 check_config["default_group"] = entry["default_group"]
             else:
-                raise ValueError(
-                    f"Invalid entry in Beman Standard YAML: {entry}")
+                raise ValueError(f"Invalid entry in Beman Standard YAML: {entry}")
 
         beman_standard_check_config[check_name] = check_config
 

--- a/tools/beman-tidy/beman_tidy/lib/utils/git.py
+++ b/tools/beman-tidy/beman_tidy/lib/utils/git.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import sys

--- a/tools/beman-tidy/beman_tidy/lib/utils/string.py
+++ b/tools/beman-tidy/beman_tidy/lib/utils/string.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import re

--- a/tools/beman-tidy/beman_tidy/lib/utils/string.py
+++ b/tools/beman-tidy/beman_tidy/lib/utils/string.py
@@ -14,7 +14,11 @@ def is_beman_snake_case(name):
     It must NOT end with a C++ target standard version - e.g. 17, 20, 23, 26, 32, etc.
     """
 
-    return name[:6] == "beman." and is_snake_case(name[6:]) and not re.match(".*[0-9]+$", name[6:])
+    return (
+        name[:6] == "beman."
+        and is_snake_case(name[6:])
+        and not re.match(".*[0-9]+$", name[6:])
+    )
 
 
 def match_badges(string):
@@ -25,7 +29,9 @@ def match_badges(string):
         return None
 
     badges_str = re.findall(r"!\[[^\]]+\]\([^)]+\)", string)
-    return [re.match(r"!\[([^\]]+)\]\(([^)]+)\)", badge).groups() for badge in badges_str]
+    return [
+        re.match(r"!\[([^\]]+)\]\(([^)]+)\)", badge).groups() for badge in badges_str
+    ]
 
 
 def skip_lines(lines, n):

--- a/tools/beman-tidy/beman_tidy/lib/utils/terminal.py
+++ b/tools/beman-tidy/beman_tidy/lib/utils/terminal.py
@@ -12,8 +12,9 @@ def run_command(command, return_stdout=False, cwd=None):
     """
     print(f"Running command: {command} with cwd: {cwd}")
     if return_stdout:
-        bin = subprocess.Popen(command, shell=True,
-                               stdout=subprocess.PIPE, cwd=cwd).stdout.read()
+        bin = subprocess.Popen(
+            command, shell=True, stdout=subprocess.PIPE, cwd=cwd
+        ).stdout.read()
         return bin.decode("utf-8")
     else:
         return subprocess.run(command, shell=True, cwd=cwd).returncode

--- a/tools/beman-tidy/beman_tidy/lib/utils/terminal.py
+++ b/tools/beman-tidy/beman_tidy/lib/utils/terminal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import subprocess

--- a/tools/beman-tidy/tests/conftest.py
+++ b/tools/beman-tidy/tests/conftest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import pytest

--- a/tools/beman-tidy/tests/conftest.py
+++ b/tools/beman-tidy/tests/conftest.py
@@ -25,7 +25,7 @@ def _setup_test_environment():
     root_dir = Path(__file__).parent.parent
 
     # Add the project root to PYTHONPATH if not already there
-    if str(root_dir) not in os.environ.get('PYTHONPATH', ''):
-        os.environ['PYTHONPATH'] = f"{root_dir}:{os.environ.get('PYTHONPATH', '')}"
+    if str(root_dir) not in os.environ.get("PYTHONPATH", ""):
+        os.environ["PYTHONPATH"] = f"{root_dir}:{os.environ.get('PYTHONPATH', '')}"
 
     yield

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/conftest.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/conftest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import pytest

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/conftest.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/conftest.py
@@ -5,6 +5,7 @@ import pytest
 
 from tests.utils.conftest import mock_repo_info, mock_beman_standard_check_config  # noqa: F401
 
+
 @pytest.fixture(autouse=True)
 def repo_info(mock_repo_info):  # noqa: F811
     return mock_repo_info

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import pytest

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
@@ -4,13 +4,23 @@
 import pytest
 from pathlib import Path
 
-from tests.utils.file_testcase_runners import file_testcases_run_valid, file_testcases_run_invalid, file_testcases_run_fix_invalid
+from tests.utils.file_testcase_runners import (
+    file_testcases_run_valid,
+    file_testcases_run_invalid,
+    file_testcases_run_fix_invalid,
+)
+
 # Actual tested checks.
-from beman_tidy.lib.checks.beman_standard.readme import ReadmeTitleCheck, ReadmeBadgesCheck, ReadmeLibraryStatusCheck
+from beman_tidy.lib.checks.beman_standard.readme import (
+    ReadmeTitleCheck,
+    ReadmeBadgesCheck,
+    ReadmeLibraryStatusCheck,
+)
 
 test_data_prefix = "tests/lib/checks/beman_standard/readme/data"
 valid_prefix = f"{test_data_prefix}/valid"
 invalid_prefix = f"{test_data_prefix}/invalid"
+
 
 def test__README_TITLE__valid(repo_info, beman_standard_check_config):
     """Test that a valid README.md title passes the check"""
@@ -25,8 +35,9 @@ def test__README_TITLE__valid(repo_info, beman_standard_check_config):
         Path(f"{valid_prefix}/README-v4.md"),
     ]
 
-    file_testcases_run_valid(valid_readme_paths, ReadmeTitleCheck,
-                             repo_info, beman_standard_check_config)
+    file_testcases_run_valid(
+        valid_readme_paths, ReadmeTitleCheck, repo_info, beman_standard_check_config
+    )
 
 
 def test__README_TITLE__invalid(repo_info, beman_standard_check_config):
@@ -39,8 +50,9 @@ def test__README_TITLE__invalid(repo_info, beman_standard_check_config):
         Path(f"{invalid_prefix}/invalid-title-v4.md"),
     ]
 
-    file_testcases_run_invalid(invalid_readme_paths, ReadmeTitleCheck,
-                               repo_info, beman_standard_check_config)
+    file_testcases_run_invalid(
+        invalid_readme_paths, ReadmeTitleCheck, repo_info, beman_standard_check_config
+    )
 
 
 def test__README_TITLE__fix_invalid(repo_info, beman_standard_check_config):
@@ -53,7 +65,8 @@ def test__README_TITLE__fix_invalid(repo_info, beman_standard_check_config):
     ]
 
     file_testcases_run_fix_invalid(
-        invalid_readme_paths, ReadmeTitleCheck, repo_info, beman_standard_check_config)
+        invalid_readme_paths, ReadmeTitleCheck, repo_info, beman_standard_check_config
+    )
 
 
 def test__README_BADGES__valid(repo_info, beman_standard_check_config):
@@ -65,8 +78,9 @@ def test__README_BADGES__valid(repo_info, beman_standard_check_config):
         Path(f"{valid_prefix}/README-v4.md"),
     ]
 
-    file_testcases_run_valid(valid_readme_paths, ReadmeBadgesCheck,
-                             repo_info, beman_standard_check_config)
+    file_testcases_run_valid(
+        valid_readme_paths, ReadmeBadgesCheck, repo_info, beman_standard_check_config
+    )
 
 
 def test__README_BADGES__invalid(repo_info, beman_standard_check_config):
@@ -78,8 +92,9 @@ def test__README_BADGES__invalid(repo_info, beman_standard_check_config):
         Path(f"{invalid_prefix}/invalid-badge-v3.md"),
     ]
 
-    file_testcases_run_invalid(invalid_readme_paths, ReadmeBadgesCheck,
-                               repo_info, beman_standard_check_config)
+    file_testcases_run_invalid(
+        invalid_readme_paths, ReadmeBadgesCheck, repo_info, beman_standard_check_config
+    )
 
 
 @pytest.mark.skip(reason="NOT implemented")
@@ -97,8 +112,12 @@ def test__README_LIBRARY_STATUS__valid(repo_info, beman_standard_check_config):
         Path(f"{valid_prefix}/README-v4.md"),
     ]
 
-    file_testcases_run_valid(valid_readme_paths, ReadmeLibraryStatusCheck,
-                             repo_info, beman_standard_check_config)
+    file_testcases_run_valid(
+        valid_readme_paths,
+        ReadmeLibraryStatusCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
 
 
 def test__README_LIBRARY_STATUS__invalid(repo_info, beman_standard_check_config):
@@ -110,8 +129,12 @@ def test__README_LIBRARY_STATUS__invalid(repo_info, beman_standard_check_config)
         Path(f"{invalid_prefix}/invalid-status-line-v3.md"),
     ]
 
-    file_testcases_run_invalid(invalid_readme_paths, ReadmeLibraryStatusCheck,
-                               repo_info, beman_standard_check_config)
+    file_testcases_run_invalid(
+        invalid_readme_paths,
+        ReadmeLibraryStatusCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
 
 
 @pytest.mark.skip(reason="NOT implemented")

--- a/tools/beman-tidy/tests/utils/conftest.py
+++ b/tools/beman-tidy/tests/utils/conftest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import pytest

--- a/tools/beman-tidy/tests/utils/directory_testcase_runners.py
+++ b/tools/beman-tidy/tests/utils/directory_testcase_runners.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 # TODO: Implement directory testcase runners

--- a/tools/beman-tidy/tests/utils/file_testcase_runners.py
+++ b/tools/beman-tidy/tests/utils/file_testcase_runners.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import os

--- a/tools/beman-tidy/tests/utils/file_testcase_runners.py
+++ b/tools/beman-tidy/tests/utils/file_testcase_runners.py
@@ -4,28 +4,41 @@
 import os
 from pathlib import Path
 
-def file_testcase_run(file_path, check_class, repo_info, beman_standard_check_config, expected_result):
+
+def file_testcase_run(
+    file_path, check_class, repo_info, beman_standard_check_config, expected_result
+):
     check_instance = check_class(repo_info, beman_standard_check_config)
     check_instance.path = Path(file_path)
     check_instance.log_level = True
 
-    assert check_instance.pre_check(
-    ) is True, f"[{check_instance.__class__.__name__}] pre_check() failed for {file_path}"
-    assert check_instance.check(
-    ) is expected_result, f"[{check_instance.__class__.__name__}] check() failed for {file_path}"
+    assert check_instance.pre_check() is True, (
+        f"[{check_instance.__class__.__name__}] pre_check() failed for {file_path}"
+    )
+    assert check_instance.check() is expected_result, (
+        f"[{check_instance.__class__.__name__}] check() failed for {file_path}"
+    )
 
 
-def file_testcase_run_valid(file_path, check_class, repo_info, beman_standard_check_config):
-    file_testcase_run(file_path, check_class, repo_info,
-                      beman_standard_check_config, True)
+def file_testcase_run_valid(
+    file_path, check_class, repo_info, beman_standard_check_config
+):
+    file_testcase_run(
+        file_path, check_class, repo_info, beman_standard_check_config, True
+    )
 
 
-def file_testcase_run_invalid(file_path, check_class, repo_info, beman_standard_check_config):
-    file_testcase_run(file_path, check_class, repo_info,
-                      beman_standard_check_config, False)
+def file_testcase_run_invalid(
+    file_path, check_class, repo_info, beman_standard_check_config
+):
+    file_testcase_run(
+        file_path, check_class, repo_info, beman_standard_check_config, False
+    )
 
 
-def file_testcase_run_fix_invalid(invalid_file_path, check_class, repo_info, beman_standard_check_config):
+def file_testcase_run_fix_invalid(
+    invalid_file_path, check_class, repo_info, beman_standard_check_config
+):
     check_instance = check_class(repo_info, beman_standard_check_config)
     check_instance.path = Path(f"{invalid_file_path}.delete_me")
     check_instance.write(invalid_file_path.read_text())
@@ -42,23 +55,39 @@ def file_testcase_run_fix_invalid(invalid_file_path, check_class, repo_info, bem
     os.remove(f"{invalid_file_path}.delete_me")
 
 
-def file_testcases_run(file_paths, check_class, repo_info, beman_standard_check_config, expected_result):
+def file_testcases_run(
+    file_paths, check_class, repo_info, beman_standard_check_config, expected_result
+):
     for file_path in file_paths:
-        file_testcase_run(file_path, check_class, repo_info,
-                          beman_standard_check_config, expected_result)
+        file_testcase_run(
+            file_path,
+            check_class,
+            repo_info,
+            beman_standard_check_config,
+            expected_result,
+        )
 
 
-def file_testcases_run_valid(file_paths, check_class, repo_info, beman_standard_check_config):
-    file_testcases_run(file_paths, check_class, repo_info,
-                       beman_standard_check_config, True)
+def file_testcases_run_valid(
+    file_paths, check_class, repo_info, beman_standard_check_config
+):
+    file_testcases_run(
+        file_paths, check_class, repo_info, beman_standard_check_config, True
+    )
 
 
-def file_testcases_run_invalid(file_paths, check_class, repo_info, beman_standard_check_config):
-    file_testcases_run(file_paths, check_class, repo_info,
-                       beman_standard_check_config, False)
+def file_testcases_run_invalid(
+    file_paths, check_class, repo_info, beman_standard_check_config
+):
+    file_testcases_run(
+        file_paths, check_class, repo_info, beman_standard_check_config, False
+    )
 
 
-def file_testcases_run_fix_invalid(invalid_file_paths, check_class, repo_info, beman_standard_check_config):
+def file_testcases_run_fix_invalid(
+    invalid_file_paths, check_class, repo_info, beman_standard_check_config
+):
     for invalid_file_path in invalid_file_paths:
         file_testcase_run_fix_invalid(
-            invalid_file_path, check_class, repo_info, beman_standard_check_config)
+            invalid_file_path, check_class, repo_info, beman_standard_check_config
+        )


### PR DESCRIPTION
This PR does several things.

1. It changes the top-level CML check to use existing logic. This one is pretty self-explanatory.

2. There was a bug that caused repository details to print alongside the output of beman-tidy. Fixes #101
![before](https://github.com/user-attachments/assets/a4ff14a2-16f2-43b9-89be-d755425cae58)
This has been fixed now.
![after](https://github.com/user-attachments/assets/ec11b1b4-0c06-4337-b21d-b4fab01b6b98)

3. The Python shebang used previously mandated the use of Python at path `/usr/bin/python3` instead of using the recommended shebang `/usr/bin/env python3`. In case of the former, we don't let the user use the Python they want. If there is no Python at `/usr/bin`, we're screwed. The latter respects the user's `$PATH` and venv. It also follows official Python portability guidelines set in [PEP 394](https://peps.python.org/pep-0394/). This, of course, only matters if the script is executed directly (`./cli`), but it's worth correcting if we have them.

4. Improves the coverage reporting for beman-tidy by showing total coverage when running with `--require-all`. It also adds a yellow coloured print for partial coverage. 
![1](https://github.com/user-attachments/assets/57ea1f68-9089-4765-acd2-4e755f0049b9)
![2](https://github.com/user-attachments/assets/b99a1722-bf77-49f5-af20-62faefe22557)

5. Mass formats the repo because the next PR will contain the pre-commit config changes that add linting and formatting to CI, and as a hook.