### PR TITLE
[beman-tidy] add Python linting and formatting to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,14 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+
+  # Python linting and formatting
+  # config file: ruff.toml (not currently present but add if needed)
+  # https://docs.astral.sh/ruff/configuration/
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.1
+    hooks:
+      - id: ruff-check
+        files: ^tools/beman-tidy/
+      - id: ruff-format
+        files: ^tools/beman-tidy/


### PR DESCRIPTION
Adds the ruff hook to pre-commit to lint and format beman-tidy Python files. This will only lint beman-tidy for now unless changed. I think it would be good to make this general. 

The reason this isn't in #100 is because that PR formats `tools/beman-tidy/beman_tidy/lib/pipeline.py` and causes some linter failures. I could disable them or fix them but I chose to leave that problem for the next person because: 
- I didn't touch any logic in that file, just formatted it
- That's a problem for someone genuinely working with that file.
- Disabling those warnings or fixing them in a formatting context doesn't seem right.
