### PR TITLE
Revert "style: add linting and formatting to pre-commit for python"

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,14 +11,3 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
-
-  # Python linting and formatting
-  # config file: ruff.toml (not currently present but add if needed)
-  # https://docs.astral.sh/ruff/configuration/
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.1
-    hooks:
-      - id: ruff-check
-        files: ^tools/beman-tidy/
-      - id: ruff-format
-        files: ^tools/beman-tidy/


### PR DESCRIPTION
This reverts commit 0c768a799a087652224d652eb122a60b34e6c53f.

This commit passed CI for its pull request but broke CI for main, because the pre-commit CI check only runs on files that differ, whereas the on-merge CI check for main checks all the files in the repository, and some of the files in beman-tidy fail the linter.

This commit should be reapplied when `pre-commit run --all-files` succeeds.