### PR TITLE
[beman-tidy] add Python linting and formatting to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,3 +11,14 @@ repos:
     rev: v2.3.0
     hooks:
       - id: codespell
+
+  # Python linting and formatting
+  # config file: ruff.toml (not currently present but add if needed)
+  # https://docs.astral.sh/ruff/configuration/
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.12.1
+    hooks:
+      - id: ruff-check
+        files: ^tools/beman-tidy/
+      - id: ruff-format
+        files: ^tools/beman-tidy/

--- a/tools/beman-tidy/beman_tidy/lib/pipeline.py
+++ b/tools/beman-tidy/beman_tidy/lib/pipeline.py
@@ -7,15 +7,16 @@ from .checks.system.registry import get_registered_beman_standard_checks
 from .checks.system.git import DisallowFixInplaceAndUnstagedChangesCheck
 
 # import all the implemented checks.
-from .checks.beman_standard.cmake import *  # noqa: F401
-from .checks.beman_standard.cpp import *  # noqa: F401
-from .checks.beman_standard.directory import *  # noqa: F401
-from .checks.beman_standard.file import *  # noqa: F401
-from .checks.beman_standard.general import *  # noqa: F401
-from .checks.beman_standard.license import *  # noqa: F401
-from .checks.beman_standard.readme import *  # noqa: F401
-from .checks.beman_standard.release import *  # noqa: F401
-from .checks.beman_standard.toplevel import *  # noqa: F401
+# TODO: Consider removing F403 from ignored lint checks
+from .checks.beman_standard.cmake import *  # noqa: F401, F403
+from .checks.beman_standard.cpp import *  # noqa: F401, F403
+from .checks.beman_standard.directory import *  # noqa: F401, F403
+from .checks.beman_standard.file import *  # noqa: F401, F403
+from .checks.beman_standard.general import *  # noqa: F401, F403
+from .checks.beman_standard.license import *  # noqa: F401, F403
+from .checks.beman_standard.readme import *  # noqa: F401, F403
+from .checks.beman_standard.release import *  # noqa: F401, F403
+from .checks.beman_standard.toplevel import *  # noqa: F401, F403
 
 red_color = "\033[91m"
 green_color = "\033[92m"


### PR DESCRIPTION
Let's try #104 again. This time with everything passing.
![image](https://github.com/user-attachments/assets/c2a2487a-cda4-4ea2-b93d-c6f92992ca89)
