### PR TITLE
Add toolchain for Clang with libc++

### DIFF
--- a/cmake/llvm-libc++-toolchain.cmake
+++ b/cmake/llvm-libc++-toolchain.cmake
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: BSL-1.0
+
+# This toolchain file is not meant to be used directly,
+# but to be invoked by CMake preset and GitHub CI.
+#
+# This toolchain file configures for LLVM family of compiler.
+#
+# BEMAN_BUILDSYS_SANITIZER:
+# This optional CMake parameter is not meant for public use and is subject to
+# change.
+# Possible values:
+# - MaxSan: configures clang and clang++ to use all available non-conflicting
+#           sanitizers.
+# - TSan:   configures clang and clang++ to enable the use of thread sanitizer.
+
+include(${CMAKE_CURRENT_LIST_DIR}/llvm-toolchain.cmake)
+
+set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++" CACHE STRING "" FORCE)


### PR DESCRIPTION
This inherits from the non-libc++ Clang toolchain file, but adds a -stdlib=libc++ parameter.