### PR TITLE
Fix libc++ toolchain file

### DIFF
--- a/cmake/llvm-libc++-toolchain.cmake
+++ b/cmake/llvm-libc++-toolchain.cmake
@@ -15,4 +15,6 @@
 
 include(${CMAKE_CURRENT_LIST_DIR}/llvm-toolchain.cmake)
 
-set(CMAKE_CXX_FLAGS_INIT "-stdlib=libc++" CACHE STRING "" FORCE)
+if(NOT CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
+  string(APPEND CMAKE_CXX_FLAGS " -stdlib=libc++")
+endif()

--- a/cmake/llvm-libc++-toolchain.cmake
+++ b/cmake/llvm-libc++-toolchain.cmake
@@ -16,5 +16,5 @@
 include(${CMAKE_CURRENT_LIST_DIR}/llvm-toolchain.cmake)
 
 if(NOT CMAKE_CXX_FLAGS MATCHES "-stdlib=libc\\+\\+")
-  string(APPEND CMAKE_CXX_FLAGS " -stdlib=libc++")
+    string(APPEND CMAKE_CXX_FLAGS " -stdlib=libc++")
 endif()


### PR DESCRIPTION
Previously, when a user specified -DCMAKE_CXX_FLAGS on the command line, it would blow away the -stdlib=libc++ parameter.