### PR TITLE
[beman-tidy] Fix README.BADGES to check for multiple badge categories

### DIFF
--- a/tools/beman-tidy/beman_tidy/.beman-standard.yml
+++ b/tools/beman-tidy/beman_tidy/.beman-standard.yml
@@ -58,11 +58,16 @@ README.TITLE:
     - type: RECOMMENDATION
 README.BADGES:
     - type: REQUIREMENT
-    - values: [
+    - values:
+        - library_status: [
             "![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)",
             "![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_production_ready_api_may_undergo_changes.svg)",
             "![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_production_ready_stable_api.svg)",
             "![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_retired.svg)"
+        ]
+        - standard_target: [
+            "![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)",
+            "![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)"
         ]
 README.PURPOSE:
     - type: RECOMMENDATION

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
@@ -51,24 +51,40 @@ class ReadmeBadgesCheck(ReadmeBaseCheck):
 
     def check(self):
         """
-        self.config["values"] contains a fixed set of Beman badges.
+        self.config["values"] contains a fixed set of Beman badges,
+        check .beman-standard.yml for the desired format.
         """
-        badges = self.config["values"]
-        assert len(badges) == 4  # The number of library maturity model states
 
-        # Check if exactly one of the required badges is present.
-        badge_count = len([badge for badge in badges if self.has_content(badge)])
-        if badge_count != 1:
-            self.log(
-                f"The file '{self.path}' does not contain exactly one of the required badges from {badges}"
-            )
-            return False
+        def validate_badges(category, badges):
+            if category == "library_status":
+                assert len(badges) == 4  # The number of library maturity model states.
+            elif category == "standard_target":
+                assert (
+                    len(badges) == 2
+                )  # The number of standard targets specified in the Beman Standard.
 
-        return True
+        def count_badges(badges):
+            return len([badge for badge in badges if self.has_content(badge)])
+
+        count_failed = 0
+        for category_data in self.config["values"]:
+            category = list(category_data.keys())[0]
+            badges = category_data[category]
+            validate_badges(category, badges)
+
+            if count_badges(badges) != 1:
+                self.log(
+                    f"The file '{self.path}' does not contain exactly one required badge of category '{category}'."
+                )
+                count_failed += 1
+
+        return count_failed == 0
 
     def fix(self):
-        # TODO: Implement the fix.
-        pass
+        self.log(
+            "Please add required badges in README.md file. See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#readmebadges for the desired format."
+        )
+        return False
 
 
 @register_beman_standard_check("README.IMPLEMENTS")

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v1.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v1.md
@@ -3,14 +3,13 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library typo Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+![Library typo 1 Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
 
 **Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
 
-<!-- markdownlint-disable-next-line line-length -->
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-This is NOT a valid README.md according to the Beman Standard: typos in badges.
+This is NOT a valid README.md according to the Beman Standard: typos in badge for library status.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v2.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v2.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Other display text](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard typo 2 Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
@@ -12,4 +12,4 @@
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-This is NOT a valid README.md according to the Beman Standard: invalid badge display text.
+This is NOT a valid README.md according to the Beman Standard: typos in badge for standard target.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v4.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v4.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![other description 1](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![other description 2](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
@@ -12,4 +12,4 @@
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-This is NOT a valid README.md according to the Beman Standard: other description in badge for library status.
+This is NOT a valid README.md according to the Beman Standard: other description in badge for standard target.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v5.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v5.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![other description 1](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_non-sense.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
@@ -12,4 +12,4 @@
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-This is NOT a valid README.md according to the Beman Standard: other description in badge for library status.
+This is NOT a valid README.md according to the Beman Standard: non-sense badge for library status (broken badge URL).

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v6.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v6.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![other description 1](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp-non-sense.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
@@ -12,4 +12,4 @@
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-This is NOT a valid README.md according to the Beman Standard: other description in badge for library status.
+This is NOT a valid README.md according to the Beman Standard: non-sense badge for standard target (broken badge URL).

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v7.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v7.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![other description 1](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
@@ -12,4 +12,4 @@
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-This is NOT a valid README.md according to the Beman Standard: other description in badge for library status.
+This is NOT a valid README.md according to the Beman Standard: 1/2 badges are missing (standard target).

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v8.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/invalid/invalid-badge-v8.md
@@ -1,9 +1,9 @@
-# beman.optional: C++26 Optional Library
+# beman.exemplar: A Beman Library Exemplar
 
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
@@ -12,4 +12,4 @@
 
 **Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
 
-This is NOT a valid README.md according to the Beman Standard: wrong library name.
+This is NOT a valid README.md according to the Beman Standard: 1/2 badges are missing (library status).

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v1.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v1.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v2.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v2.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_production_ready_api_may_undergo_changes.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v3.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v3.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_production_ready_stable_api.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp29.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v4.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v4.md
@@ -3,7 +3,7 @@
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
 <!-- markdownlint-disable-next-line line-length -->
-![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_retired.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
 
 <!-- markdownlint-disable-next-line line-length -->
 `beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
@@ -51,11 +51,14 @@ def test__README_TITLE__invalid(repo_info, beman_standard_check_config):
     Test that an invalid README.md title fails the check.
     """
     invalid_readme_paths = [
+        # Title: Wrong Title Format
         Path(f"{invalid_prefix}/invalid.md"),
+        # Title: Missing . in beman.exemplar
         Path(f"{invalid_prefix}/invalid-title-v1.md"),
+        # Title: Missing : after beman.exemplar
         Path(f"{invalid_prefix}/invalid-title-v2.md"),
+        # Title: Wromg name beman.exemaplar vs beman.optional
         Path(f"{invalid_prefix}/invalid-title-v3.md"),
-        Path(f"{invalid_prefix}/invalid-title-v4.md"),
     ]
 
     run_check_for_each_path(
@@ -75,7 +78,6 @@ def test__README_TITLE__fix_inplace(repo_info, beman_standard_check_config):
         Path(f"{invalid_prefix}/invalid-title-v1.md"),
         Path(f"{invalid_prefix}/invalid-title-v2.md"),
         Path(f"{invalid_prefix}/invalid-title-v3.md"),
-        Path(f"{invalid_prefix}/invalid-title-v4.md"),
     ]
 
     run_fix_inplace_for_each_file_path(
@@ -88,9 +90,13 @@ def test__README_BADGES__valid(repo_info, beman_standard_check_config):
     Test that a valid README.md badges passes the check.
     """
     valid_readme_paths = [
+        # Badges: under development status and cpp26 target
         Path(f"{valid_prefix}/README-v1.md"),
+        # Badges: production ready (api may undergo changes) status and cpp26 target
         Path(f"{valid_prefix}/README-v2.md"),
+        # Badges: production ready (stable api) status and cpp29 target
         Path(f"{valid_prefix}/README-v3.md"),
+        # Badges: retired status and cpp26 target
         Path(f"{valid_prefix}/README-v4.md"),
     ]
 
@@ -109,9 +115,22 @@ def test__README_BADGES__invalid(repo_info, beman_standard_check_config):
     """
     invalid_readme_paths = [
         Path(f"{invalid_prefix}/invalid.md"),
+        # Badges: typos in badge for library status
         Path(f"{invalid_prefix}/invalid-badge-v1.md"),
+        # Badges: typos in badge for standard target
         Path(f"{invalid_prefix}/invalid-badge-v2.md"),
+        # Badges: other description in badge for library status
         Path(f"{invalid_prefix}/invalid-badge-v3.md"),
+        # Badges: other description in badge for standard target
+        Path(f"{invalid_prefix}/invalid-badge-v4.md"),
+        # Badges: non-sense badge for library status (broken badge URL)
+        Path(f"{invalid_prefix}/invalid-badge-v5.md"),
+        # Badges: non-sense badge for standard target (broken badge URL)
+        Path(f"{invalid_prefix}/invalid-badge-v6.md"),
+        # Badges: 1/2 badges are missing (standard target)
+        Path(f"{invalid_prefix}/invalid-badge-v7.md"),
+        # Badges: 1/2 badges are missing (library status)
+        Path(f"{invalid_prefix}/invalid-badge-v8.md"),
     ]
 
     run_check_for_each_path(


### PR DESCRIPTION
[beman-tidy] Fix README.BADGES to check for multiple badge categories - #51 


broken after https://github.com/bemanproject/beman/commit/61455cb5f9f3e4bbd6164eb920bd29b6df42d728