### PR TITLE
[beman-tidy] Implement LICENSE.CRITERIA

### DIFF
--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
@@ -8,7 +8,6 @@ from pathlib import Path
 
 from ..base.file_base_check import FileBaseCheck
 from ..system.registry import register_beman_standard_check
-from ....lib.utils.git import load_beman_standard_config, get_repo_info
 
 # [LICENSE.*] checks category.
 # All checks in this file extend the LicenseBaseCheck class.

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from ..base.file_base_check import FileBaseCheck
 from ..system.registry import register_beman_standard_check
-
+from ....lib.utils.git import load_beman_standard_config, get_repo_info
 
 # [LICENSE.*] checks category.
 # All checks in this file extend the LicenseBaseCheck class.
@@ -97,4 +97,20 @@ class LicenseApacheLLVMCheck(LicenseBaseCheck):
         )
 
 
-# TODO LICENSE.CRITERIA
+@register_beman_standard_check("LICENSE.CRITERIA")
+class LicenseCriteriaCheck(LicenseBaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def check(self):
+        self.log(
+            "beman-tidy cannot actually check LICENSE.CRITERIA. Please ignore this message if LICENSE.APPROVED has passed. "
+            "See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#licensecriteria for more information."
+        )
+        return True
+
+    def fix(self):
+        self.log(
+            "beman-tidy cannot actually check LICENSE.CRITERIA. Please ignore this message if LICENSE.APPROVED has passed. "
+            "See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#licensecriteria for more information."
+        )

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
@@ -12,6 +12,7 @@ from tests.utils.path_runners import (
 from beman_tidy.lib.checks.beman_standard.license import (
     LicenseApprovedCheck,
     LicenseApacheLLVMCheck,
+    LicenseCriteriaCheck,
 )
 
 test_data_prefix = "tests/lib/checks/beman_standard/license/data"
@@ -116,13 +117,39 @@ def test__LICENSE_APACHE_LLVM__fix_inplace(repo_info, beman_standard_check_confi
 
 
 def test__LICENSE_CRITERIA__valid(repo_info, beman_standard_check_config):
-    pass
+    valid_license_paths = [
+        # Apache License v2.0 with LLVM Exceptions
+        Path(f"{valid_prefix}/valid-LICENSE-v1"),
+    ]
+
+    run_check_for_each_path(
+        True,
+        valid_license_paths,
+        LicenseCriteriaCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
 
 
+@pytest.mark.skip(reason="NOT implemented")
 def test__LICENSE_CRITERIA__invalid(repo_info, beman_standard_check_config):
+    # LICENSE.CRITERIA cannot be invalid. Check license.py.
+    invalid_license_paths = [
+        # Almost valid LICENSE, but without header
+        Path(f"{invalid_prefix}/invalid-LICENSE-v1"),
+    ]
+
+    run_check_for_each_path(
+        False,
+        invalid_license_paths,
+        LicenseCriteriaCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
     pass
 
 
 @pytest.mark.skip(reason="NOT implemented")
 def test__LICENSE_CRITERIA__fix_inplace(repo_info, beman_standard_check_config):
+    # LICENSE.CRITERIA cannot be invalid, so no need for fix inplace. Check license.py.
     pass

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
@@ -12,6 +12,7 @@ from tests.utils.path_runners import (
 from beman_tidy.lib.checks.beman_standard.license import (
     LicenseApprovedCheck,
     LicenseApacheLLVMCheck,
+    LicenseCriteriaCheck
 )
 
 test_data_prefix = "tests/lib/checks/beman_standard/license/data"
@@ -112,4 +113,17 @@ def test__LICENSE_APACHE_LLVM__invalid(repo_info, beman_standard_check_config):
 
 @pytest.mark.skip(reason="NOT implemented")
 def test__LICENSE_APACHE_LLVM__fix_inplace(repo_info, beman_standard_check_config):
+    pass
+
+
+def test__LICENSE_CRITERIA__valid(repo_info, beman_standard_check_config):
+    pass
+
+
+def test__LICENSE_CRITERIA__invalid(repo_info, beman_standard_check_config):
+    pass
+
+
+@pytest.mark.skip(reason="NOT implemented")
+def test__LICENSE_CRITERIA__fix_inplace(repo_info, beman_standard_check_config):
     pass

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
@@ -118,8 +118,10 @@ def test__LICENSE_APACHE_LLVM__fix_inplace(repo_info, beman_standard_check_confi
 
 def test__LICENSE_CRITERIA__valid(repo_info, beman_standard_check_config):
     valid_license_paths = [
-        # Apache License v2.0 with LLVM Exceptions
+        # LICENSE.CRITERIA is always true, e.g. for valid file with Apache License v2.0 with LLVM Exceptions.
         Path(f"{valid_prefix}/valid-LICENSE-v1"),
+        # LICENSE.CRITERIA is always true, e.g. for invalid file.
+        Path(f"{invalid_prefix}/invalid-LICENSE-v1"),
     ]
 
     run_check_for_each_path(
@@ -134,18 +136,6 @@ def test__LICENSE_CRITERIA__valid(repo_info, beman_standard_check_config):
 @pytest.mark.skip(reason="NOT implemented")
 def test__LICENSE_CRITERIA__invalid(repo_info, beman_standard_check_config):
     # LICENSE.CRITERIA cannot be invalid. Check license.py.
-    invalid_license_paths = [
-        # Almost valid LICENSE, but without header
-        Path(f"{invalid_prefix}/invalid-LICENSE-v1"),
-    ]
-
-    run_check_for_each_path(
-        False,
-        invalid_license_paths,
-        LicenseCriteriaCheck,
-        repo_info,
-        beman_standard_check_config,
-    )
     pass
 
 

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
@@ -12,7 +12,6 @@ from tests.utils.path_runners import (
 from beman_tidy.lib.checks.beman_standard.license import (
     LicenseApprovedCheck,
     LicenseApacheLLVMCheck,
-    LicenseCriteriaCheck
 )
 
 test_data_prefix = "tests/lib/checks/beman_standard/license/data"


### PR DESCRIPTION
Implemented LICENSE.CRITERIA - #56 

- Added check(log message only)
- Added fix(log message only)

Maybe a more comprehensive check could be added, perhaps if LICENSE.APPROVED check passes, then LICENSE.CRITERIA passes. Let me know your thoughts.