### PR TITLE
[beman-tidy] Implement RELEASE.*

### DIFF
--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/release.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/release.py
@@ -1,6 +1,10 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import re
+from beman_tidy.lib.checks.beman_standard.readme import ReadmeBaseCheck
+from ..system.registry import register_beman_standard_check
+
 # [RELEASE.*] checks category.
 # Note: Data is stored online - e.g. https://github.com/bemanproject/exemplar/releases
 # TBD - Do we want to implement these checks?
@@ -12,4 +16,33 @@
 # TODO RELEASE.NOTES
 
 
-# TODO RELEASE.GODBOLT_TRUNK_VERSION
+@register_beman_standard_check("RELEASE.GODBOLT_TRUNK_VERSION")
+class ReleaseGodboltTrunkVersionCheck(ReadmeBaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def check(self):
+        """
+        Check that the Godbolt badge is present in the root README.md file.
+        If present, this assumes that the trunk version is available on Godbolt.
+
+        e.g. [![Compiler Explorer Example](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/Gc6Y9j6zf)
+        Note: Only the suffix of the https://godbolt.org/z/* has dynamic content.
+        """
+
+        content = self.read()
+        regex = re.compile(
+            r"\[!\[Compiler Explorer Example\]\(https://img\.shields\.io/badge/Try%20it%20on%20Compiler%20Explorer-grey\?logo=compilerexplorer&logoColor=67c52a\)\]\(https://godbolt\.org/z/([a-zA-Z0-9]+)\)"
+        )
+        if not re.search(regex, content):
+            self.log(
+                f"The file '{self.path}' does not contain a Compiler Explorer badge - trunk version assumed to be missing."
+            )
+            return False
+
+        return True
+
+    def fix(self):
+        self.log(
+            "beman-tidy cannot fix this issue. See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#releasegodbolt_trunk_version."
+        )

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/release.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/release.py
@@ -2,15 +2,33 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import re
+from beman_tidy.lib.checks.base.base_check import BaseCheck
 from beman_tidy.lib.checks.beman_standard.readme import ReadmeBaseCheck
 from ..system.registry import register_beman_standard_check
 
 # [RELEASE.*] checks category.
 # Note: Data is stored online - e.g. https://github.com/bemanproject/exemplar/releases
-# TBD - Do we want to implement these checks?
+# beman-tidy is an offline tool, so it cannot check these issues,
+# but for some of them it will try some heuristics.
 
 
-# TODO RELEASE.GITHUB
+@register_beman_standard_check("RELEASE.GITHUB")
+class ReleaseGithubCheck(BaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def check(self):
+        # Need to always return True, as beman-tidy is an offline tool
+        # that does not have access to the GitHub API.
+        self.log(
+            "beman-tidy cannot check this issue. See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#releasegithub."
+        )
+        return True
+
+    def fix(self):
+        self.log(
+            "beman-tidy cannot fix this issue. See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#releasegithub."
+        )
 
 
 # TODO RELEASE.NOTES

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/release.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/release.py
@@ -32,6 +32,23 @@ class ReleaseGithubCheck(BaseCheck):
 
 
 # TODO RELEASE.NOTES
+@register_beman_standard_check("RELEASE.NOTES")
+class ReleaseNotesCheck(BaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def check(self):
+        # Need to always return True, as beman-tidy is an offline tool
+        # that does not have access to the GitHub API.
+        self.log(
+            "beman-tidy cannot check this issue. See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#releasenotes."
+        )
+        return True
+
+    def fix(self):
+        self.log(
+            "beman-tidy cannot fix this issue. See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#releasenotes."
+        )
 
 
 @register_beman_standard_check("RELEASE.GODBOLT_TRUNK_VERSION")

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
@@ -144,6 +144,10 @@ def test__README_BADGES__invalid(repo_info, beman_standard_check_config):
 
 @pytest.mark.skip(reason="NOT implemented")
 def test__README_BADGES__fix_inplace(repo_info, beman_standard_check_config):
+    """
+    Test that the fix method corrects an invalid README.md badges.
+    """
+    # Cannot determine what badges to create. fix() is not implemented.
     pass
 
 
@@ -190,6 +194,10 @@ def test__README_IMPLEMENTS__invalid(repo_info, beman_standard_check_config):
 
 @pytest.mark.skip(reason="NOT implemented")
 def test__README_IMPLEMENTS__fix_inplace(repo_info, beman_standard_check_config):
+    """
+    Test that the fix method corrects an invalid README.md "Implements".
+    """
+    # Cannot determine what implements to create. fix() is not implemented.
     pass
 
 
@@ -235,4 +243,8 @@ def test__README_LIBRARY_STATUS__invalid(repo_info, beman_standard_check_config)
 
 @pytest.mark.skip(reason="NOT implemented")
 def test__README_LIBRARY_STATUS__fix_inplace(repo_info, beman_standard_check_config):
+    """
+    Test that the fix method corrects an invalid README.md library status.
+    """
+    # Cannot determine what library status to create. fix() is not implemented.
     pass

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/release/conftest.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/release/conftest.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+
+from tests.utils.conftest import mock_repo_info, mock_beman_standard_check_config  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def repo_info(mock_repo_info):  # noqa: F811
+    return mock_repo_info
+
+
+@pytest.fixture
+def beman_standard_check_config(mock_beman_standard_check_config):  # noqa: F811
+    return mock_beman_standard_check_config

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/release/data/invalid/repo-exemplar-v1/README.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/release/data/invalid/repo-exemplar-v1/README.md
@@ -1,0 +1,28 @@
+# beman.exemplar: A Beman Library Exemplar
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+<!-- markdownlint-disable-next-line line-length -->
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+
+<!-- markdownlint-disable-next-line line-length -->
+`beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
+
+**Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
+
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
+
+<!-- markdownlint-disable-next-line line-length -->
+This is a valid README.md file that follows the Beman Standard: the title is properly formatted with the library name and a short description.
+
+This is a valid README.md file that follows the Beman Standard: the badges are properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the purpose is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the implements is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the library status is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the license is properly formatted.
+
+This is an invalid README.md file that follows the Beman Standard: the Godbolt badge is missing.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/release/data/valid/repo-exemplar-v1/README.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/release/data/valid/repo-exemplar-v1/README.md
@@ -1,0 +1,28 @@
+# beman.exemplar: A Beman Library Exemplar
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+<!-- markdownlint-disable-next-line line-length -->
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg) [![Compiler Explorer Example](https://img.shields.io/badge/Try%20it%20on%20Compiler%20Explorer-grey?logo=compilerexplorer&logoColor=67c52a)](https://godbolt.org/z/Gc6Y9j6zf)
+
+<!-- markdownlint-disable-next-line line-length -->
+`beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
+
+**Implements**: `std::identity` proposed in [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
+
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/BEMAN_LIBRARY_MATURITY_MODEL.md#under-development-and-not-yet-ready-for-production-use)
+
+<!-- markdownlint-disable-next-line line-length -->
+This is a valid README.md file that follows the Beman Standard: the title is properly formatted with the library name and a short description.
+
+This is a valid README.md file that follows the Beman Standard: the badges are properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the purpose is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the implements is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the library status is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the license is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the Godbolt badge is present.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/release/test_release.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/release/test_release.py
@@ -12,6 +12,7 @@ from tests.utils.path_runners import (
 from beman_tidy.lib.checks.beman_standard.release import (
     ReleaseGithubCheck,
     ReleaseGodboltTrunkVersionCheck,
+    ReleaseNotesCheck,
 )
 
 test_data_prefix = "tests/lib/checks/beman_standard/release/data"
@@ -50,6 +51,43 @@ def test__RELEASE_GITHUB__invalid(repo_info, beman_standard_check_config):
 @pytest.mark.skip(reason="NOT implemented")
 def test__RELEASE_GITHUB__fix_inplace(repo_info, beman_standard_check_config):
     # RELEASE.GITHUB always passes, as beman-tidy is an offline tool.
+    pass
+
+
+def test__RELEASE_NOTES__valid(repo_info, beman_standard_check_config):
+    """
+    Test that repositories with release notes pass the check.
+    """
+    valid_repo_paths = [
+        # RELEASE.NOTES always passes, as beman-tidy is an offline tool.
+        Path(f"{valid_prefix}/repo-exemplar-v1/"),
+        Path(f"{invalid_prefix}/repo-exemplar-v1/"),
+    ]
+
+    run_check_for_each_path(
+        True,
+        valid_repo_paths,
+        ReleaseNotesCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
+
+
+@pytest.mark.skip(reason="NOT implemented")
+def test__RELEASE_NOTES__invalid(repo_info, beman_standard_check_config):
+    """
+    Test that repositories with missing release notes fail the check.
+    """
+    # RELEASE.NOTES always passes, as beman-tidy is an offline tool.
+    pass
+
+
+@pytest.mark.skip(reason="NOT implemented")
+def test__RELEASE_NOTES__fix_inplace(repo_info, beman_standard_check_config):
+    """
+    Test that repositories with missing release notes fail the check.
+    """
+    # RELEASE.NOTES always passes, as beman-tidy is an offline tool.
     pass
 
 

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/release/test_release.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/release/test_release.py
@@ -10,12 +10,47 @@ from tests.utils.path_runners import (
 
 # Actual tested checks.
 from beman_tidy.lib.checks.beman_standard.release import (
+    ReleaseGithubCheck,
     ReleaseGodboltTrunkVersionCheck,
 )
 
 test_data_prefix = "tests/lib/checks/beman_standard/release/data"
 valid_prefix = f"{test_data_prefix}/valid"
 invalid_prefix = f"{test_data_prefix}/invalid"
+
+
+def test__RELEASE_GITHUB__valid(repo_info, beman_standard_check_config):
+    """
+    Test that repositories with GitHub release pass the check.
+    """
+    valid_repo_paths = [
+        # RELEASE.GITHUB always passes, as beman-tidy is an offline tool.
+        Path(f"{valid_prefix}/repo-exemplar-v1/"),
+        Path(f"{invalid_prefix}/repo-exemplar-v1/"),
+    ]
+
+    run_check_for_each_path(
+        True,
+        valid_repo_paths,
+        ReleaseGithubCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
+
+
+@pytest.mark.skip(reason="NOT implemented")
+def test__RELEASE_GITHUB__invalid(repo_info, beman_standard_check_config):
+    """
+    Test that repositories with missing GitHub release fail the check.
+    """
+    # RELEASE.GITHUB always passes, as beman-tidy is an offline tool.
+    pass
+
+
+@pytest.mark.skip(reason="NOT implemented")
+def test__RELEASE_GITHUB__fix_inplace(repo_info, beman_standard_check_config):
+    # RELEASE.GITHUB always passes, as beman-tidy is an offline tool.
+    pass
 
 
 def test__RELEASE_GODBOLT_TRUNK_VERSION__valid(repo_info, beman_standard_check_config):

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/release/test_release.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/release/test_release.py
@@ -133,4 +133,8 @@ def test__RELEASE_GODBOLT_TRUNK_VERSION__invalid(
 def test__RELEASE_GODBOLT_TRUNK_VERSION__fix_inplace(
     repo_info, beman_standard_check_config
 ):
+    """
+    Test that the fix method corrects an invalid README.md Godbolt trunk version.
+    """
+    # Cannot determine what Godbolt trunk version to create. fix() is not implemented.
     pass

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/release/test_release.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/release/test_release.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+from pathlib import Path
+
+from tests.utils.path_runners import (
+    run_check_for_each_path,
+)
+
+# Actual tested checks.
+from beman_tidy.lib.checks.beman_standard.release import (
+    ReleaseGodboltTrunkVersionCheck,
+)
+
+test_data_prefix = "tests/lib/checks/beman_standard/release/data"
+valid_prefix = f"{test_data_prefix}/valid"
+invalid_prefix = f"{test_data_prefix}/invalid"
+
+
+def test__RELEASE_GODBOLT_TRUNK_VERSION__valid(repo_info, beman_standard_check_config):
+    """
+    Test that repositories with present Godbolt trunk version pass the check.
+    """
+    valid_godbolt_trunk_version_paths = [
+        # exemplar/ repo with root README.md containing valid Godbolt trunk version.
+        Path(f"{valid_prefix}/repo-exemplar-v1/"),
+    ]
+
+    run_check_for_each_path(
+        True,
+        valid_godbolt_trunk_version_paths,
+        ReleaseGodboltTrunkVersionCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
+
+
+def test__RELEASE_GODBOLT_TRUNK_VERSION__invalid(
+    repo_info, beman_standard_check_config
+):
+    """
+    Test that repositories with missing Godbolt trunk version fail the check.
+    """
+    invalid_godbolt_trunk_version_paths = [
+        # exemplar/ repo root README.md without Godbolt trunk version.
+        Path(f"{invalid_prefix}/repo-exemplar-v1/"),
+    ]
+
+    run_check_for_each_path(
+        False,
+        invalid_godbolt_trunk_version_paths,
+        ReleaseGodboltTrunkVersionCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
+
+
+@pytest.mark.skip(reason="NOT implemented")
+def test__RELEASE_GODBOLT_TRUNK_VERSION__fix_inplace(
+    repo_info, beman_standard_check_config
+):
+    pass


### PR DESCRIPTION
#81  #47 #82 

[beman-tidy] Implement RELEASE.*, or better say don't implement them as we cannot.
We still need to integrate them into beman-tidy, to at least log.
<img width="1406" height="293" alt="image" src="https://github.com/user-attachments/assets/176df27a-5203-45fb-a13b-a817b3cdbe9d" />
