### PR TITLE
[beman-tidy] Add SKIPPED as a possible status for a check

### DIFF
--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/license.py
@@ -5,6 +5,7 @@ import re
 import filecmp
 import textwrap
 
+from ..base.base_check import BaseCheck
 from ..base.file_base_check import FileBaseCheck
 from ..system.registry import register_beman_standard_check
 from beman_tidy.lib.utils.git import get_beman_recommendated_license_path
@@ -97,19 +98,23 @@ class LicenseApacheLLVMCheck(LicenseBaseCheck):
 
 
 @register_beman_standard_check("LICENSE.CRITERIA")
-class LicenseCriteriaCheck(LicenseBaseCheck):
+class LicenseCriteriaCheck(BaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
         super().__init__(repo_info, beman_standard_check_config)
 
-    def check(self):
+    def should_skip(self):
+        # Cannot actually implement LICENSE.CRITERIA, so skip it.
+        # No need to run pre_check() and check() as well, as they are not implemented.
         self.log(
             "beman-tidy cannot actually check LICENSE.CRITERIA. Please ignore this message if LICENSE.APPROVED has passed. "
             "See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#licensecriteria for more information."
         )
         return True
 
+    def check(self):
+        # Check should_skip(). Stub provided to be able to instantiate the check.
+        return True
+
     def fix(self):
-        self.log(
-            "beman-tidy cannot actually check LICENSE.CRITERIA. Please ignore this message if LICENSE.APPROVED has passed. "
-            "See https://github.com/bemanproject/beman/blob/main/docs/BEMAN_STANDARD.md#licensecriteria for more information."
-        )
+        # Check should_skip().
+        return True

--- a/tools/beman-tidy/beman_tidy/lib/pipeline.py
+++ b/tools/beman-tidy/beman_tidy/lib/pipeline.py
@@ -175,10 +175,9 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
     print(
         f"Summary    REQUIREMENT: {green_color} {cnt_passed_checks['REQUIREMENT']} checks PASSED{no_color}, {red_color}{cnt_failed_checks['REQUIREMENT']} checks FAILED{no_color}, {gray_color}{cnt_skipped_checks['REQUIREMENT']} checks SKIPPED, {no_color} {cnt_not_implemented_checks['REQUIREMENT']} checks NOT IMPLEMENTED."
     )
-    if not args.require_all:
-        print(
-            f"Summary RECOMMENDATION: {green_color} {cnt_passed_checks['RECOMMENDATION']} checks PASSED{no_color}, {red_color}{cnt_failed_checks['RECOMMENDATION']} checks FAILED{no_color}, {gray_color}{cnt_skipped_checks['RECOMMENDATION']} checks SKIPPED, {no_color} {cnt_not_implemented_checks['RECOMMENDATION']} checks NOT IMPLEMENTED."
-        )
+    print(
+        f"Summary RECOMMENDATION: {green_color} {cnt_passed_checks['RECOMMENDATION']} checks PASSED{no_color}, {red_color}{cnt_failed_checks['RECOMMENDATION']} checks FAILED{no_color}, {gray_color}{cnt_skipped_checks['RECOMMENDATION']} checks SKIPPED, {no_color} {cnt_not_implemented_checks['RECOMMENDATION']} checks NOT IMPLEMENTED."
+    )
 
     # Always print the coverage.
     cnt_passed_requirement = (

--- a/tools/beman-tidy/beman_tidy/lib/pipeline.py
+++ b/tools/beman-tidy/beman_tidy/lib/pipeline.py
@@ -35,46 +35,54 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
     @return: The number of failed checks.
     """
 
-    """
-    Helper function to log messages.
-    """
-
     def log(msg):
+        """
+        Helper function to log messages.
+        """
         if args.verbose:
             print(msg)
 
-    """
-    Helper function to run a check.
-    @param check_class: The check class type to run.
-    @param log_enabled: Whether to log the check result.
-    @return: True if the check passed, False otherwise.
-    """
-
-    def run_check(check_class, log_enabled=args.verbose):
+    def run_check(check_class, log_enabled=args.verbose, require_all=args.require_all):
+        """
+        Helper function to run a check.
+        @param check_class: The check class type to run.
+        @param log_enabled: Whether to log the check result.
+        @return: True if the check passed, False otherwise.
+        """
         check_instance = check_class(args.repo_info, beman_standard_check_config)
-        check_instance.log_enabled = log_enabled
-        check_type = check_instance.type
+        if require_all and check_instance.type == "RECOMMENDATION":
+            check_instance.convert_to_requirement()
 
+        # Check if the check should be skipped, with logging disabled (by default).
+        if check_instance.should_skip():
+            log(f"Running check [{check_instance.type}][{check_instance.name}] ... ")
+            check_instance.log_enabled = log_enabled
+            check_instance.should_skip()  # Run should_skip() again, with logging enabled.
+            log(
+                f"Running check [{check_instance.type}][{check_instance.name}] ... {gray_color}SKIPPED{no_color}\n"
+            )
+            return check_instance.type, "SKIPPED"
+
+        # Run the check on normal mode.
         log(f"Running check [{check_instance.type}][{check_instance.name}] ... ")
-
+        check_instance.log_enabled = log_enabled
         if (check_instance.pre_check() and check_instance.check()) or (
             args.fix_inplace and check_instance.fix()
         ):
             log(
                 f"\tcheck [{check_instance.type}][{check_instance.name}] ... {green_color}PASSED{no_color}\n"
             )
-            return check_type, True
+            return check_instance.type, "PASSED"
         else:
             log(
                 f"\tcheck [{check_instance.type}][{check_instance.name}] ... {red_color}FAILED{no_color}\n"
             )
-            return check_type, False
-
-    """
-    Main pipeline.
-    """
+            return check_instance.type, "FAILED"
 
     def run_pipeline_helper():
+        """
+        Helper function to run the pipeline.
+        """
         # Internal checks
         if args.fix_inplace:
             run_check(DisallowFixInplaceAndUnstagedChangesCheck, log_enabled=True)
@@ -82,113 +90,171 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
         implemented_checks = get_registered_beman_standard_checks()
         all_checks = beman_standard_check_config
 
-        cnt_passed = {
-            "REQUIREMENT": 0,
-            "RECOMMENDATION": 0,
-        }
-        cnt_failed = {
-            "REQUIREMENT": 0,
-            "RECOMMENDATION": 0,
-        }
-        for check_name in checks_to_run:
-            if check_name not in implemented_checks:
-                continue
-
-            check_type, passed = run_check(implemented_checks[check_name])
-            if passed:
-                cnt_passed[check_type] += 1
-            else:
-                cnt_failed[check_type] += 1
-
-        cnt_skipped = {
-            "REQUIREMENT": 0,
-            "RECOMMENDATION": 0,
-        }
+        # All checks from the Beman Standard.
         cnt_all_beman_standard_checks = {
             "REQUIREMENT": 0,
             "RECOMMENDATION": 0,
         }
+        # All checks from the Beman Standard that are implemented.
         cnt_implemented_checks = {
             "REQUIREMENT": 0,
             "RECOMMENDATION": 0,
         }
+        # All checks from the Beman Standard that are not implemented.
+        cnt_not_implemented_checks = {
+            "REQUIREMENT": 0,
+            "RECOMMENDATION": 0,
+        }
+        # All implemented checks that passed.
+        cnt_passed_checks = {
+            "REQUIREMENT": 0,
+            "RECOMMENDATION": 0,
+        }
+        # All implemented checks that failed.
+        cnt_failed_checks = {
+            "REQUIREMENT": 0,
+            "RECOMMENDATION": 0,
+        }
+        # All implemented checks that were skipped (e.g., dummy implementation
+        # or it cannot be implemented).
+        cnt_skipped_checks = {
+            "REQUIREMENT": 0,
+            "RECOMMENDATION": 0,
+        }
+
+        # Run the checks.
+        for check_name in checks_to_run:
+            if check_name not in implemented_checks:
+                continue
+
+            check_type, status = run_check(implemented_checks[check_name])
+            if status == "PASSED":
+                cnt_passed_checks[check_type] += 1
+            elif status == "FAILED":
+                cnt_failed_checks[check_type] += 1
+            elif status == "SKIPPED":
+                cnt_skipped_checks[check_type] += 1
+            else:
+                raise ValueError(f"Invalid status: {status}")
+
+        # Count the checks from the Beman Standard.
         for check_name in all_checks:
-            check_type = all_checks[check_name]["type"]
+            check_type = (
+                all_checks[check_name]["type"]
+                if not args.require_all
+                else "REQUIREMENT"
+            )
             cnt_all_beman_standard_checks[check_type] += 1
 
             if check_name not in implemented_checks:
-                cnt_skipped[check_type] += 1
+                cnt_not_implemented_checks[check_type] += 1
             else:
                 cnt_implemented_checks[check_type] += 1
 
         return (
-            cnt_passed,
-            cnt_failed,
-            cnt_skipped,
-            cnt_implemented_checks,
+            cnt_passed_checks,
+            cnt_failed_checks,
+            cnt_skipped_checks,
             cnt_all_beman_standard_checks,
+            cnt_implemented_checks,
+            cnt_not_implemented_checks,
         )
 
     log("beman-tidy pipeline started ...\n")
     (
-        cnt_passed,
-        cnt_failed,
-        cnt_skipped,
-        cnt_implemented_checks,
+        cnt_passed_checks,
+        cnt_failed_checks,
+        cnt_skipped_checks,
         cnt_all_beman_standard_checks,
+        cnt_implemented_checks,
+        cnt_not_implemented_checks,
     ) = run_pipeline_helper()
     log("\nbeman-tidy pipeline finished.\n")
 
     # Always print the summary.
     print(
-        f"Summary    REQUIREMENT: {green_color} {cnt_passed['REQUIREMENT']} checks PASSED{no_color}, {red_color}{cnt_failed['REQUIREMENT']} checks FAILED{no_color}, {gray_color}{cnt_skipped['REQUIREMENT']} skipped (NOT implemented).{no_color}"
+        f"Summary    REQUIREMENT: {green_color} {cnt_passed_checks['REQUIREMENT']} checks PASSED{no_color}, {red_color}{cnt_failed_checks['REQUIREMENT']} checks FAILED{no_color}, {gray_color}{cnt_skipped_checks['REQUIREMENT']} checks SKIPPED, {no_color} {cnt_not_implemented_checks['REQUIREMENT']} checks NOT IMPLEMENTED."
     )
-    print(
-        f"Summary RECOMMENDATION: {green_color} {cnt_passed['RECOMMENDATION']} checks PASSED{no_color}, {red_color}{cnt_failed['RECOMMENDATION']} checks FAILED{no_color}, {gray_color}{cnt_skipped['RECOMMENDATION']} skipped (NOT implemented).{no_color}"
-    )
+    if not args.require_all:
+        print(
+            f"Summary RECOMMENDATION: {green_color} {cnt_passed_checks['RECOMMENDATION']} checks PASSED{no_color}, {red_color}{cnt_failed_checks['RECOMMENDATION']} checks FAILED{no_color}, {gray_color}{cnt_skipped_checks['RECOMMENDATION']} checks SKIPPED, {no_color} {cnt_not_implemented_checks['RECOMMENDATION']} checks NOT IMPLEMENTED."
+        )
 
     # Always print the coverage.
-    coverage_requirement = round(
-        cnt_passed["REQUIREMENT"] / cnt_implemented_checks["REQUIREMENT"] * 100, 2
+    cnt_passed_requirement = (
+        cnt_passed_checks["REQUIREMENT"] + cnt_skipped_checks["REQUIREMENT"]
+        if not args.require_all
+        else cnt_passed_checks["REQUIREMENT"]
+        + cnt_skipped_checks["REQUIREMENT"]
+        + cnt_passed_checks["RECOMMENDATION"]
+        + cnt_skipped_checks["RECOMMENDATION"]
     )
-    coverage_recommendation = round(
-        cnt_passed["RECOMMENDATION"] / cnt_implemented_checks["RECOMMENDATION"] * 100, 2
-    )
-    total_passed = cnt_passed["REQUIREMENT"] + cnt_passed["RECOMMENDATION"]
-    total_implemented = (
+    total_implemented_requirement = (
         cnt_implemented_checks["REQUIREMENT"] + cnt_implemented_checks["RECOMMENDATION"]
+        if not args.require_all
+        else cnt_implemented_checks["REQUIREMENT"]
     )
+    coverage_requirement = round(
+        cnt_passed_requirement / total_implemented_requirement * 100,
+        2,
+    )
+    cnt_passed_recommendation = (
+        cnt_passed_checks["RECOMMENDATION"] + cnt_skipped_checks["RECOMMENDATION"]
+        if not args.require_all
+        else 0
+    )
+    total_implemented_recommendation = (
+        cnt_implemented_checks["RECOMMENDATION"] if not args.require_all else 0
+    )
+    coverage_recommendation = (
+        round(
+            cnt_passed_recommendation / total_implemented_recommendation * 100,
+            2,
+        )
+        if total_implemented_recommendation > 0
+        else 0
+    )
+    total_passed = (
+        cnt_passed_checks["REQUIREMENT"]
+        + cnt_passed_checks["RECOMMENDATION"]
+        + cnt_skipped_checks["REQUIREMENT"]
+        + cnt_skipped_checks["RECOMMENDATION"]
+    )
+    total_implemented = total_implemented_requirement + total_implemented_recommendation
     total_coverage = round((total_passed) / (total_implemented) * 100, 2)
     print(
-        f"\n{__calculate_coverage_color(coverage_requirement)}Coverage    REQUIREMENT: {coverage_requirement:{6}.2f}% ({cnt_passed['REQUIREMENT']}/{cnt_implemented_checks['REQUIREMENT']} checks passed).{no_color}"
+        f"\n{calculate_coverage_color(coverage_requirement)}Coverage    REQUIREMENT: {coverage_requirement:{6}.2f}% ({cnt_passed_requirement}/{total_implemented_requirement} checks passed).{no_color}"
     )
-    if args.require_all:
-        print(
-            f"{__calculate_coverage_color(coverage_recommendation)}Coverage RECOMMENDATION: {coverage_recommendation:{6}.2f}% ({cnt_passed['RECOMMENDATION']}/{cnt_implemented_checks['RECOMMENDATION']} checks passed).{no_color}"
-        )
-        print(
-            f"{__calculate_coverage_color(total_coverage)}Coverage          TOTAL: {total_coverage:{6}.2f}% ({total_passed}/{total_implemented} checks passed).{no_color}"
-        )
-    else:
-        print("Note: RECOMMENDATIONs are not included (--require-all NOT set).")
-    total_cnt_failed = cnt_failed["REQUIREMENT"] + (
-        cnt_failed["RECOMMENDATION"] if args.require_all else 0
+    print(
+        f"{calculate_coverage_color(coverage_recommendation, no_color=args.require_all)}Coverage RECOMMENDATION: {coverage_recommendation:{6}.2f}% ({cnt_passed_recommendation}/{total_implemented_recommendation} checks passed).{no_color}"
+    )
+    print(
+        f"{calculate_coverage_color(total_coverage)}Coverage          TOTAL: {total_coverage:{6}.2f}% ({total_passed}/{total_implemented} checks passed).{no_color}"
+    )
+    # else:
+    #     print("Note: RECOMMENDATIONs are not included (--require-all NOT set).")
+    total_cnt_failed = cnt_failed_checks["REQUIREMENT"] + (
+        cnt_failed_checks["RECOMMENDATION"] if args.require_all else 0
     )
 
     sys.stdout.flush()
     return total_cnt_failed
 
 
-def __calculate_coverage_color(cov):
+def calculate_coverage_color(coverage, no_color=False):
     """
     Returns the colour for the coverage print based on severity
     Green for 100%
     Red for 0%
     Yellow for anything else
+
+    Exception: If no_color is True, the color will be removed.
     """
-    if cov == 100:
+    if no_color:
+        return gray_color
+    elif coverage == 100:
         return green_color
-    elif cov == 0:
+    elif coverage == 0:
         return red_color
     else:
         return yellow_color

--- a/tools/beman-tidy/docs/dev-guide.md
+++ b/tools/beman-tidy/docs/dev-guide.md
@@ -87,9 +87,24 @@ tests/beman_standard/readme/test_readme.py::test__README_BADGES__fix_inplace SKI
   check.
   * e.g., for `check_category = "readme"` the test file is `tests/lib/checks/beman_standard/readme/test_readme.py`.
 * `test__<check_category>__<test_case_name>()` function inside the test file.
-  * e.g., for `check_category = "readme"` and `test_case_name = "valid"` the function is `test__README_TITLE__valid()`.
-  * e.g., for `check_category = "readme"` and `test_case_name = "invalid"` the function is
-    `test__README_TITLE__invalid()`.
+  * `test_case_name` can be `valid`, `invalid`, `fix_inplace` or `skipped`.
+  * If the check is implemented and must be run, add the 3 functions: `valid`, `invalid` and `fix_inplace` (some of them can be a
+    `@pytest.mark.skip(reason="NOT implemented")` decorator).
+  * If the check is implemented as a dummy (e.g., cannot be properly implemented), add the `skipped` function.
+    `should_skip()` must log a reason why it is skipped.
+  * Examples:
+    * Runnable check - `README.TITLE`:
+      * for `check_category = "readme"` and `test_case_name = "valid"` the function is `test__README_TITLE__valid()`.
+      * for `check_category = "readme"` and `test_case_name = "invalid"` the function is
+        `test__README_TITLE__invalid()`.
+      * for `check_category = "readme"` and `test_case_name = "fix_inplace"` the function is
+        `test__README_TITLE__fix_inplace()`.
+    * Skippable check - `LICENSE.CRITERIA`:
+      * for `check_category = "license"` and `test_case_name = "skipped"` the function is
+        `test__LICENSE_CRITERIA__skipped()`.
+      * `should_skip()` must log a reason why it is skipped.
+      * `should_skip()` must return `True`.
+      * `check()` and `fix()` must provide a `return True` implementation.
 * `tests/beman_standard/<check_category>/data/`: The data for the tests (e.g., files, directories, etc.).
   * e.g., for `check_category = "readme"` and `test_case_name = "valid"` the data is in
     `tests/lib/checks/beman_standard/readme/data/valid/`.

--- a/tools/beman-tidy/docs/dev-guide.md
+++ b/tools/beman-tidy/docs/dev-guide.md
@@ -88,10 +88,10 @@ tests/beman_standard/readme/test_readme.py::test__README_BADGES__fix_inplace SKI
   * e.g., for `check_category = "readme"` the test file is `tests/lib/checks/beman_standard/readme/test_readme.py`.
 * `test__<check_category>__<test_case_name>()` function inside the test file.
   * `test_case_name` can be `valid`, `invalid`, `fix_inplace` or `skipped`.
-  * If the check is implemented and must be run, add the 3 functions: `valid`, `invalid` and `fix_inplace` (some of them can be a
-    `@pytest.mark.skip(reason="NOT implemented")` decorator).
+  * If the check is implemented and must be run, add 3 test functions: `valid`, `invalid` and `fix_inplace` (some of them can be a `@pytest.mark.skip(reason="NOT implemented")` decorator, but at least one must be actually implemented).
   * If the check is implemented as a dummy (e.g., cannot be properly implemented), add the `skipped` function.
     `should_skip()` must log a reason why it is skipped.
+  * Note: The number of tests is already enforced by a unit test in `tests/lib/checks/system/test_registry.py`, which is looking for the test functions for new added checks!
   * Examples:
     * Runnable check - `README.TITLE`:
       * for `check_category = "readme"` and `test_case_name = "valid"` the function is `test__README_TITLE__valid()`.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/license/test_license.py
@@ -68,8 +68,11 @@ def test__LICENSE_APPROVED__invalid(repo_info, beman_standard_check_config):
     )
 
 
-@pytest.mark.skip(reason="NOT implemented")
 def test__LICENSE_APPROVED__fix_inplace(repo_info, beman_standard_check_config):
+    """
+    Test that the fix method corrects an invalid LICENSE file.
+    """
+    # Cannot determine what license to create. fix() is not implemented.
     pass
 
 
@@ -113,33 +116,16 @@ def test__LICENSE_APACHE_LLVM__invalid(repo_info, beman_standard_check_config):
 
 @pytest.mark.skip(reason="NOT implemented")
 def test__LICENSE_APACHE_LLVM__fix_inplace(repo_info, beman_standard_check_config):
+    """
+    Test that the fix method corrects an invalid LICENSE file.
+    """
+    # Cannot determine what license to create. fix() is not implemented.
     pass
 
 
-def test__LICENSE_CRITERIA__valid(repo_info, beman_standard_check_config):
-    valid_license_paths = [
-        # LICENSE.CRITERIA is always true, e.g. for valid file with Apache License v2.0 with LLVM Exceptions.
-        Path(f"{valid_prefix}/valid-LICENSE-v1"),
-        # LICENSE.CRITERIA is always true, e.g. for invalid file.
-        Path(f"{invalid_prefix}/invalid-LICENSE-v1"),
-    ]
-
-    run_check_for_each_path(
-        True,
-        valid_license_paths,
-        LicenseCriteriaCheck,
-        repo_info,
-        beman_standard_check_config,
-    )
-
-
-@pytest.mark.skip(reason="NOT implemented")
-def test__LICENSE_CRITERIA__invalid(repo_info, beman_standard_check_config):
-    # LICENSE.CRITERIA cannot be invalid. Check license.py.
-    pass
-
-
-@pytest.mark.skip(reason="NOT implemented")
-def test__LICENSE_CRITERIA__fix_inplace(repo_info, beman_standard_check_config):
-    # LICENSE.CRITERIA cannot be invalid, so no need for fix inplace. Check license.py.
-    pass
+def test__LICENSE_CRITERIA__skipped(repo_info, beman_standard_check_config):
+    """
+    Test that LICENSE.CRITERIA is always skipped.
+    """
+    # LICENSE.CRITERIA is skipped, as it cannot be implemented.
+    assert LicenseCriteriaCheck(repo_info, beman_standard_check_config).should_skip()

--- a/tools/beman-tidy/tests/lib/checks/system/__init__.py
+++ b/tools/beman-tidy/tests/lib/checks/system/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception

--- a/tools/beman-tidy/tests/lib/checks/system/conftest.py
+++ b/tools/beman-tidy/tests/lib/checks/system/conftest.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+
+from tests.utils.conftest import mock_repo_info, mock_beman_standard_check_config  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def repo_info(mock_repo_info):  # noqa: F811
+    return mock_repo_info
+
+
+@pytest.fixture(autouse=True)
+def beman_standard_check_config(mock_beman_standard_check_config):  # noqa: F811
+    return mock_beman_standard_check_config

--- a/tools/beman-tidy/tests/lib/checks/system/test_registry.py
+++ b/tools/beman-tidy/tests/lib/checks/system/test_registry.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import inspect
+from pathlib import Path
+
+from beman_tidy.lib.checks.system.registry import (
+    get_registered_beman_standard_checks,
+)
+from tests.utils.registry import (
+    find_pytest_test_functions_for_check,
+    find_filename_for_check,
+)
+
+
+def test__get_registered_beman_standard_checks__valid(
+    repo_info, beman_standard_check_config
+):
+    """
+    Test that the get_registered_beman_standard_checks() function returns the correct checks
+    and verify that each registered check has corresponding pytest test functions.
+    """
+    all_registered_checks = get_registered_beman_standard_checks()
+    for check_name, check_class in all_registered_checks.items():
+        # Convert check name to test function pattern.
+        # e.g., "README.TITLE" -> "README_TITLE"
+        check_pattern = check_name.replace(".", "_")
+
+        # Find the filename for the check class.
+        filename = find_filename_for_check(check_name)
+        assert filename is not None, (
+            f"Missing filename for {check_name} in beman_tidy/lib/checks/beman_standard/"
+        )
+        expected_function_path = (
+            Path(__file__).parent.parent.parent.parent
+            / "lib"
+            / "checks"
+            / "beman_standard"
+            / filename
+            / f"test_{filename}.py"
+        )
+
+        # Find all test functions that match the check name.
+        test_functions = find_pytest_test_functions_for_check(check_pattern)
+
+        # Decide if the check is runnable or skipped.
+        check_instance = check_class(repo_info, beman_standard_check_config)
+        if check_instance.should_skip():
+            # Skipped checks have exactly one test function.
+            expected_function_name = f"test__{check_pattern}__skipped"
+            assert len(test_functions) == 1, (
+                f"Expected exactly one test function for {check_name}: {expected_function_name} at {expected_function_path}"
+            )
+
+            actual_function_path = Path(test_functions[0]["file"])
+            actual_function_name = test_functions[0]["function"]
+
+            assert expected_function_path == actual_function_path, (
+                f"Test function path should match the expected pattern: {actual_function_path} != {expected_function_path}"
+            )
+            assert expected_function_name == actual_function_name, (
+                f"Test function name should match the expected pattern: {actual_function_name} != {expected_function_name}"
+            )
+        else:
+            # Runnable checks have exactly three test functions.
+            expected_function_names = [
+                f"test__{check_pattern}__valid",
+                f"test__{check_pattern}__invalid",
+                f"test__{check_pattern}__fix_inplace",
+            ]
+            assert len(test_functions) == len(expected_function_names), (
+                f"Expected exactly three test functions for runnable check {check_name}: {expected_function_names} at {expected_function_path}"
+            )
+
+            for test_function in test_functions:
+                actual_function_path = Path(test_function["file"])
+                actual_function_name = test_function["function"]
+                assert expected_function_path == actual_function_path, (
+                    f"Test function path should match the expected pattern: {actual_function_path} != {expected_function_path}"
+                )
+                assert any(
+                    expected_function_name == actual_function_name
+                    for expected_function_name in expected_function_names
+                ), (
+                    f"Test function name should match the expected pattern: {actual_function_name} != {expected_function_name}"
+                )
+
+
+def test__registry_completeness__check():
+    """
+    Test that verifies the completeness of the registry system.
+    This is a comprehensive test of all registry functionality.
+    """
+    from beman_tidy.lib.checks.system.registry import (
+        get_all_beman_standard_check_names,
+        get_beman_standard_check_by_name,
+        get_beman_standard_check_name_by_class,
+    )
+
+    registered_checks = get_registered_beman_standard_checks()
+    registered_names = get_all_beman_standard_check_names()
+
+    # Basic registry validation
+    assert len(registered_checks) > 0, "Registry should not be empty"
+    assert len(registered_names) == len(registered_checks), (
+        "Names list and checks dict should have same length"
+    )
+
+    # Test each registry function
+    for check_name in registered_names:
+        # Test get_beman_standard_check_by_name.
+        check_class = get_beman_standard_check_by_name(check_name)
+        assert check_class is not None, (
+            f"Should be able to retrieve check class for '{check_name}'"
+        )
+        assert check_class == registered_checks[check_name], (
+            "Retrieved class should match registry entry"
+        )
+
+        # Test get_beman_standard_check_name_by_class
+        reverse_name = get_beman_standard_check_name_by_class(check_class)
+        assert reverse_name == check_name, (
+            f"Reverse lookup should work for '{check_name}'"
+        )
+
+        # Verify class structure.
+        assert inspect.isclass(check_class), (
+            f"'{check_name}' should be registered to a class"
+        )
+        assert hasattr(check_class, "check"), (
+            f"'{check_name}' class should have 'check' method"
+        )
+        assert hasattr(check_class, "fix"), (
+            f"'{check_name}' class should have 'fix' method"
+        )
+
+
+def test__registry_no_duplicates__check():
+    """
+    Test that no check class is registered multiple times.
+    """
+    registered_checks = get_registered_beman_standard_checks()
+
+    # Create reverse mapping: class -> list of names.
+    class_to_names = {}
+    for check_name, check_class in registered_checks.items():
+        if check_class not in class_to_names:
+            class_to_names[check_class] = []
+        class_to_names[check_class].append(check_name)
+
+    # Verify each class is only registered once
+    duplicates = []
+    for check_class, check_names in class_to_names.items():
+        if len(check_names) > 1:
+            duplicates.append((check_class.__name__, check_names))
+
+    assert len(duplicates) == 0, f"Found duplicate registrations: {duplicates}"

--- a/tools/beman-tidy/tests/utils/registry.py
+++ b/tools/beman-tidy/tests/utils/registry.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import importlib
+import inspect
+from pathlib import Path
+import re
+
+
+def find_pytest_test_functions_for_check(check_pattern):
+    """
+    Find all pytest test functions that match the given check pattern.
+
+    Args:
+        check_pattern: The check pattern (e.g., "README_TITLE")
+
+    Returns:
+        List of dictionaries containing module and function information
+    """
+    # Search in beman_standard test directories
+    beman_standard_tests_dir = (
+        Path(__file__).parent.parent / "lib" / "checks" / "beman_standard"
+    )
+    if not beman_standard_tests_dir.exists():
+        return []
+
+    test_functions = []
+    # Iterate through all test modules in beman_standard
+    for category_dir in beman_standard_tests_dir.iterdir():
+        if category_dir.is_dir() and not category_dir.name.startswith("__"):
+            test_file = category_dir / f"test_{category_dir.name}.py"
+
+            if test_file.exists():
+                # Import the test module
+                try:
+                    module_name = f"tests.lib.checks.beman_standard.{category_dir.name}.test_{category_dir.name}"
+                    spec = importlib.util.spec_from_file_location(
+                        module_name, test_file
+                    )
+                    module = importlib.util.module_from_spec(spec)
+                    spec.loader.exec_module(module)
+
+                    # Find test functions that match our pattern
+                    for name, obj in inspect.getmembers(module):
+                        if (
+                            inspect.isfunction(obj)
+                            and name.startswith("test__")
+                            and check_pattern in name
+                        ):
+                            test_functions.append(
+                                {
+                                    "module": module_name,
+                                    "function": name,
+                                    "file": str(test_file),
+                                    "category": category_dir.name,
+                                }
+                            )
+
+                except Exception as e:
+                    print(f"Error loading module {test_file}: {e}")
+
+    return test_functions
+
+
+def find_filename_for_check(check_name):
+    """
+    Find the Python file that contains the check class for the given check name.
+
+    Args:
+        check_name: The check name (e.g., "README.TITLE")
+
+    Returns:
+        The filename of the check class
+    """
+    # Search in beman_standard test directories
+    beman_standard_lib_dir = (
+        Path(__file__).parent.parent.parent
+        / "beman_tidy"
+        / "lib"
+        / "checks"
+        / "beman_standard"
+    )
+    if not beman_standard_lib_dir.exists():
+        assert False, (
+            f"Beman Standard library directory does not exist: {beman_standard_lib_dir}"
+        )
+        return None
+
+    # Find @register_beman_standard_check("{check_name}") inside the file
+    for file in beman_standard_lib_dir.glob("*.py"):
+        regex = r"@register_beman_standard_check\(\"{check_name}\"\)".format(
+            check_name=check_name
+        )
+        with open(file, "r") as f:
+            if re.search(regex, f.read()):
+                return file.name.replace(".py", "")
+
+    # If no file is found, return None.
+    assert False, f"No file found for {check_name} in {beman_standard_lib_dir}"
+    return None


### PR DESCRIPTION
#147 beman-tidy] Add SKIPPED as a possible status for a check

Updates:

1. Proposed a pattern to skip a chec: `BaseCheck.should_skip(): return False` method which can be overridden in derived classes: https://github.com/bemanproject/infra/pull/148/files#diff-3bdc17c1450533d17e01fa9a7048a1088909117a964cc9f0986db4701bf7ca50R85-R91. If this method returns true, `check()` and `fix()` are not called , but should exists. `pre_check()` is also not called.

2. Applied this proposal to LIBRARY.CRITERIA, which should be SKIPPED.

4.  Change the logging / output format for the tool to use SKIPPED category. Coverage formulas are also changed.

5. Update `docs/dev-guide.md` to specify when should write proper tests vs skipped tests. We always need a set of tests to know the explicit state of the tool.

6. Add tests to check your tests! Because in Python everything is an object, including the types, I added tests in `tests/lib/checks/system/test_registry.py`, which essentially checks that for __ALL__ registered check classes the proper set of tests is defined at the right location! a.k.a. we won't have anymore situations like in the past, were some checks were added in Sofia without tests.
Examples of failures:
- If I delete `test__LICENSE_CRITERIA__skipped` from this branch (or move it to wrong location)
<img width="1725" height="213" alt="image" src="https://github.com/user-attachments/assets/713db307-ea09-43e0-bde4-b9010b465b69" />
- Or if I have wrong function name:
<img width="1728" height="210" alt="image" src="https://github.com/user-attachments/assets/319def7c-6b22-4ec8-a0b9-4def3fded004" />






New logging format examples:
- non-verbose, exemplar, failing 1 x RECOMMANDATION
<img width="1088" height="109" alt="image" src="https://github.com/user-attachments/assets/cc97dbc2-a6bd-432a-9c3e-821c75691d01" />
- non-verbose, exemplar with --require-all, failing 1 x REQUIREMENT (simplified output)
<img width="981" height="103" alt="image" src="https://github.com/user-attachments/assets/6ab4d020-fa78-4cca-a715-c3322a32b691" />

- verbose, exemplar, failing 1 x RECOMMANDATION - check `SKIPPED` new tag
<img width="1723" height="888" alt="image" src="https://github.com/user-attachments/assets/d7c1b2fb-4a6d-4d93-ae67-b04c8a129e19" />
- verbose, exemplar with --require-all, failing 1 x REQUIREMENT (simplified output) - check that `WARNING` is converted to `ERROR`
<img width="1728" height="881" alt="image" src="https://github.com/user-attachments/assets/bc9d15fd-5cee-4841-bbad-7296f8d32608" />

