### PR TITLE
[beman-tidy] CI flows should test, build, install and run beman-tidy

### DIFF
--- a/.github/workflows/beman-tidy.yml
+++ b/.github/workflows/beman-tidy.yml
@@ -1,18 +1,19 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: beman-tidy lint, testing and installing
+name: beman-tidy tests
 
 on:
   push:
     branches:
       - main
   pull_request:
+  workflow_call:
   workflow_dispatch:
   schedule:
     - cron: '0 5 * * *' #  08:00AM EEST (@neatudarius' timezone) -> 05:00AM UTC
 
 jobs:
-  run_tests:
+  run_linter:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -32,11 +33,50 @@ jobs:
         run: |
           uv run ruff check --diff
 
+  run_tests:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/beman-tidy
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync environment
+        run: |
+          uv sync
+
       - name: Run tests
         run: |
           uv run pytest tests/ -v
 
   build_and_install:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/beman-tidy
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync environment
+        run: |
+          uv sync
+
+      - name: Build and install beman-tidy
+        run: |
+         uv clean
+         uv build
+         python3 -m pip install dist/beman_tidy-0.1.0-py3-none-any.whl --force-reinstall
+         beman-tidy --help
+
+  run_on_exemplar:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -66,6 +106,6 @@ jobs:
           beman-tidy --verbose --require-all .
 
   create-issue-when-fault:
-    needs: [run_tests, build_and_install]
-    if: failure() && github.event.schedule == '0 5 * * *' # 08:00AM EEST (@neatudarius' timezone) -> 05:00AM UTC
+    needs: [run_linter, run_tests, build_and_install, run_on_exemplar]
+    if: failure() && (github.event_name == 'workflow_call' || github.event_name == 'schedule')
     uses: ./.github/workflows/reusable-beman-create-issue-when-fault.yml

--- a/.github/workflows/beman-tidy.yml
+++ b/.github/workflows/beman-tidy.yml
@@ -1,6 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-name: beman-tidy tests
+name: beman-tidy lint, testing and installing
 
 on:
   push:
@@ -8,9 +8,11 @@ on:
       - main
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 5 * * *' #  08:00AM EEST (@neatudarius' timezone) -> 05:00AM UTC
 
 jobs:
-  tests:
+  run_tests:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -28,9 +30,42 @@ jobs:
 
       - name: Run linter
         run: |
-          echo "Running linter"
           uv run ruff check --diff
 
       - name: Run tests
         run: |
           uv run pytest tests/ -v
+
+  build_and_install:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tools/beman-tidy
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Sync environment
+        run: |
+          uv sync
+
+      - name: Build and install beman-tidy
+        run: |
+         uv clean
+         uv build
+         python3 -m pip install dist/beman_tidy-0.1.0-py3-none-any.whl --force-reinstall
+         beman-tidy --help
+
+      - name: Run installed beman-tidy on exemplar repo
+        run: |
+          git clone https://github.com/bemanproject/exemplar.git
+          cd exemplar/ # Testing that beman-tidy can be run from any path, e.g. from the exemplar repo.
+          beman-tidy --verbose --require-all .
+
+  create-issue-when-fault:
+    needs: [run_tests, build_and_install]
+    if: failure() && github.event.schedule == '0 5 * * *' # 08:00AM EEST (@neatudarius' timezone) -> 05:00AM UTC
+    uses: ./.github/workflows/reusable-beman-create-issue-when-fault.yml

--- a/.github/workflows/reusable-beman-create-issue-when-fault.yml
+++ b/.github/workflows/reusable-beman-create-issue-when-fault.yml
@@ -3,6 +3,7 @@
 name: 'Beman issue creation workflow'
 on:
   workflow_call:
+  workflow_dispatch:
 jobs:
   create-issue:
     runs-on: ubuntu-latest
@@ -11,15 +12,15 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create issue
         run: |
-          issue_num=$(gh issue list -s open -S "[SCHEDULED-BUILD] Build & Test failure" -L 1 --json number | jq 'if length == 0 then -1 else .[0].number end')
-          body="**Build-and-Test Failure Report**
+          issue_num=$(gh issue list -s open -S "[SCHEDULED-BUILD] infra repo CI job failure" -L 1 --json number | jq 'if length == 0 then -1 else .[0].number end')
+          body="**CI job failure Report**
           - **Time of Failure**: $(date -u '+%B %d, %Y, %H:%M %Z')
           - **Commit**: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
           - **Action Run**: [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
-          The scheduled build-and-test triggered by cron has failed.
+          The scheduled job triggered by cron has failed.
           Please investigate the logs and recent changes associated with this commit or rerun the workflow if you believe this is an error."
           if [[ $issue_num -eq -1 ]]; then
-            gh issue create --repo ${{ github.repository }} --title "[SCHEDULED-BUILD] Build & Test failure" --body "$body"
+            gh issue create --repo ${{ github.repository }} --title "[SCHEDULED-BUILD] infra repo CI job failure" --body "$body" --assignee ${{ github.actor }}
           else
             gh issue comment --repo ${{ github.repository }} $issue_num --body "$body"
           fi

--- a/.github/workflows/reusable-beman-create-issue-when-fault.yml
+++ b/.github/workflows/reusable-beman-create-issue-when-fault.yml
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: 'Beman issue creation workflow'
+on:
+  workflow_call:
+jobs:
+  create-issue:
+    runs-on: ubuntu-latest
+    steps:
+      # See https://github.com/cli/cli/issues/5075
+      - uses: actions/checkout@v4
+      - name: Create issue
+        run: |
+          issue_num=$(gh issue list -s open -S "[SCHEDULED-BUILD] Build & Test failure" -L 1 --json number | jq 'if length == 0 then -1 else .[0].number end')
+          body="**Build-and-Test Failure Report**
+          - **Time of Failure**: $(date -u '+%B %d, %Y, %H:%M %Z')
+          - **Commit**: [${{ github.sha }}](${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }})
+          - **Action Run**: [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})
+          The scheduled build-and-test triggered by cron has failed.
+          Please investigate the logs and recent changes associated with this commit or rerun the workflow if you believe this is an error."
+          if [[ $issue_num -eq -1 ]]; then
+            gh issue create --repo ${{ github.repository }} --title "[SCHEDULED-BUILD] Build & Test failure" --body "$body"
+          else
+            gh issue comment --repo ${{ github.repository }} $issue_num --body "$body"
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
 
+[![beman-tidy tests](https://github.com/bemanproject/infra/actions/workflows/beman-tidy.yml/badge.svg)](https://github.com/bemanproject/infra/actions/workflows/beman-tidy.yml)
+
 This repository contains the infrastructure for The Beman Project. This is NOT a library repository, so it does not
 respect the usual structure of a Beman library repository nor The Beman Standard!
 


### PR DESCRIPTION
[beman-tidy] CI flows should build, install and run beman-tidy #149 . This would prevent issues such as #144 . Also, we should run CI for beman-tidy daily, and open issues on failure.

Example of automated detected failure:
- example 1: exemplar repo fails RELEASE.GODBOLT_TRUNK_VERSION - `Running beman-tidy on exemplar repo` fails
https://github.com/bemanproject/infra/actions/runs/16398536741/job/46334561853?pr=150
- example 2: tool is broken - `Build and install` passes, but `Run tool on exemplar` fails dus to wrong packaging
https://github.com/bemanproject/infra/actions/runs/16398572881/job/46334643532?pr=150
<img width="964" height="660" alt="image" src="https://github.com/user-attachments/assets/1a3ad0f0-17da-4bbb-86a8-12d30b69b2e1" />

Also, split in smaller jobs:
- failure example
<img width="656" height="328" alt="image" src="https://github.com/user-attachments/assets/68b54cff-d76f-420a-8ecd-bdfaf9ee09b6" />
- pass example
<img width="791" height="127" alt="image" src="https://github.com/user-attachments/assets/9d6801b3-c414-413f-899b-be01014b99b0" />

Note: CI is intentionally broken at this stage - check https://github.com/bemanproject/infra/pull/150#issuecomment-3094421806.
