### PR TITLE
Add a beman_install_library CMake function

### DIFF
--- a/cmake/appleclang-toolchain.cmake
+++ b/cmake/appleclang-toolchain.cmake
@@ -39,3 +39,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cmake/beman-install-library-config.cmake
+++ b/cmake/beman-install-library-config.cmake
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+include_guard(GLOBAL)
+
+# This file defines the function `beman_install_library` which is used to
+# install a library target and its headers, along with optional CMake
+# configuration files.
+#
+# The function is designed to be reusable across different Beman libraries.
+
+function(beman_install_library name)
+    # Usage
+    # -----
+    #
+    #     beman_install_library(NAME)
+    #
+    # Brief
+    # -----
+    #
+    # This function installs the specified library target and its headers.
+    # It also handles the installation of the CMake configuration files if needed.
+    #
+    # CMake variables
+    # ---------------
+    #
+    # Note that configuration of the installation is generally controlled by CMake
+    # cache variables so that they can be controlled by the user or tool running the
+    # `cmake` command. Neither `CMakeLists.txt` nor `*.cmake` files should set these
+    # variables directly.
+    #
+    # - BEMAN_INSTALL_CONFIG_FILE_PACKAGES:
+    #      List of packages that require config file installation.
+    #      If the package name is in this list, it will install the config file.
+    #
+    # - <PREFIX>_INSTALL_CONFIG_FILE_PACKAGE:
+    #      Boolean to control config file installation for the specific library.
+    #      The prefix `<PREFIX>` is the uppercased name of the library with dots
+    #      replaced by underscores.
+    #
+    if(NOT TARGET "${name}")
+        message(FATAL_ERROR "Target '${name}' does not exist.")
+    endif()
+
+    if(NOT ARGN STREQUAL "")
+        message(
+            FATAL_ERROR
+            "beman_install_library does not accept extra arguments: ${ARGN}"
+        )
+    endif()
+
+    # Given foo.bar, the component name is bar
+    string(REPLACE "." ";" name_parts "${name}")
+    # fail if the name doesn't look like foo.bar
+    list(LENGTH name_parts name_parts_length)
+    if(NOT name_parts_length EQUAL 2)
+        message(
+            FATAL_ERROR
+            "beman_install_library expects a name of the form 'beman.<name>', got '${name}'"
+        )
+    endif()
+
+    set(target_name "${name}")
+    set(install_component_name "${name}")
+    set(export_name "${name}")
+    set(package_name "${name}")
+    list(GET name_parts -1 component_name)
+
+    install(
+        TARGETS "${target_name}" COMPONENT "${install_component_name}"
+        EXPORT "${export_name}"
+        FILE_SET HEADERS
+    )
+
+    set_target_properties(
+        "${target_name}"
+        PROPERTIES EXPORT_NAME "${component_name}"
+    )
+
+    include(GNUInstallDirs)
+
+    # Determine the prefix for project-specific variables
+    string(TOUPPER "${name}" project_prefix)
+    string(REPLACE "." "_" project_prefix "${project_prefix}")
+
+    if(
+        "${name}" IN_LIST BEMAN_INSTALL_CONFIG_FILE_PACKAGES
+        OR "${project_prefix}_INSTALL_CONFIG_FILE_PACKAGE"
+    )
+        set(install_config_package ON)
+    endif()
+
+    if(install_config_package)
+        message(
+            DEBUG
+            "beman-install-library: Installing a config package for '${name}'"
+        )
+
+        include(CMakePackageConfigHelpers)
+
+        find_file(
+            config_file_template
+            NAMES "${package_name}-config.cmake.in"
+            PATHS "${CMAKE_CURRENT_SOURCE_DIR}"
+            NO_DEFAULT_PATH
+            NO_CACHE
+            REQUIRED
+        )
+        set(config_package_file
+            "${CMAKE_CURRENT_BINARY_DIR}/${package_name}-config.cmake"
+        )
+        set(package_install_dir "${CMAKE_INSTALL_LIBDIR}/cmake/${package_name}")
+        configure_package_config_file(
+            "${config_file_template}"
+            "${config_package_file}"
+            INSTALL_DESTINATION "${package_install_dir}"
+            PATH_VARS PROJECT_NAME PROJECT_VERSION
+        )
+
+        set(config_version_file
+            "${CMAKE_CURRENT_BINARY_DIR}/${package_name}-config-version.cmake"
+        )
+        write_basic_package_version_file(
+            "${config_version_file}"
+            VERSION "${PROJECT_VERSION}"
+            COMPATIBILITY ExactVersion
+        )
+
+        install(
+            FILES "${config_package_file}" "${config_version_file}"
+            DESTINATION "${package_install_dir}"
+            COMPONENT "${install_component_name}"
+        )
+
+        set(config_targets_file "${package_name}-targets.cmake")
+        install(
+            EXPORT "${export_name}"
+            DESTINATION "${package_install_dir}"
+            NAMESPACE beman::
+            FILE "${config_targets_file}"
+            COMPONENT "${install_component_name}"
+        )
+    else()
+        message(
+            DEBUG
+            "beman-install-library: Not installing a config package for '${name}'"
+        )
+    endif()
+endfunction()

--- a/cmake/gnu-toolchain.cmake
+++ b/cmake/gnu-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cmake/llvm-toolchain.cmake
+++ b/cmake/llvm-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cmake/msvc-toolchain.cmake
+++ b/cmake/msvc-toolchain.cmake
@@ -36,3 +36,6 @@ set(CMAKE_CXX_FLAGS_RELWITHDEBINFO_INIT "${RELEASE_FLAGS}")
 
 set(CMAKE_C_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
 set(CMAKE_CXX_FLAGS_RELEASE_INIT "${RELEASE_FLAGS}")
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")

--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -152,7 +152,11 @@ function(BemanExemplar_provideDependency method package_name)
                     APPEND
                     BemanExemplar_debug
                     "Redirecting find_package calls for ${BemanExemplar_pkgName} "
-                    "to FetchContent logic fetching ${BemanExemplar_repo} at "
+                    "to FetchContent logic.\n"
+                    string
+                    APPEND
+                    BemanExemplar_debug
+                    "Fetching ${BemanExemplar_repo} at "
                     "${BemanExemplar_tag} according to ${BemanExemplar_lockfile}."
                 )
                 message(DEBUG "${BemanExemplar_debug}")
@@ -177,3 +181,6 @@ cmake_language(
     SET_DEPENDENCY_PROVIDER BemanExemplar_provideDependency
     SUPPORTED_METHODS FIND_PACKAGE
 )
+
+# Add this dir to the module path so that `find_package(beman-install-library)` works
+list(APPEND CMAKE_PREFIX_PATH "${CMAKE_CURRENT_LIST_DIR}")


### PR DESCRIPTION
Problem
-------

It requires to much code with too many accurate details to install a Beman library. Also, repeating those lines of code across many libraries makes it too difficult to maintain installation logic across the project.

Solution
--------

Create beman_install_library, a CMake function for installing a Beman library. This function uses Beman Standard assumptions to make it simple for Beman libraries to mark themselves for installation.