### PR TITLE
[beman-tidy] Implement readme.purpose

### DIFF
--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
@@ -20,6 +20,7 @@ class ReadmeBaseCheck(FileBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
         super().__init__(repo_info, beman_standard_check_config, "README.md")
 
+
 @register_beman_standard_check("readme.purpose")
 class ReadmePurposeCheck(BaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):

--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
@@ -3,7 +3,7 @@
 
 import re
 
-from ..base.file_base_check import FileBaseCheck
+from ..base.file_base_check import FileBaseCheck, BaseCheck
 from ..system.registry import register_beman_standard_check
 from beman_tidy.lib.utils.string import (
     match_apache_license_v2_with_llvm_exceptions,
@@ -19,6 +19,19 @@ from beman_tidy.lib.utils.string import (
 class ReadmeBaseCheck(FileBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):
         super().__init__(repo_info, beman_standard_check_config, "README.md")
+
+@register_beman_standard_check("readme.purpose")
+class ReadmePurposeCheck(BaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def should_skip(self):
+        # Cannot actually implement readme.purpose, thus skip it.
+        self.log(
+            "beman-tidy cannot actually check readme.purpose. Please add a one line summary describing the library's purpose."
+            "See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#readmepurpose."
+        )
+        return True
 
 
 @register_beman_standard_check("readme.title")

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
@@ -11,6 +11,7 @@ from tests.utils.path_runners import (
 
 # Actual tested checks.
 from beman_tidy.lib.checks.beman_standard.readme import (
+    ReadmePurposeCheck,
     ReadmeTitleCheck,
     ReadmeBadgesCheck,
     ReadmeImplementsCheck,
@@ -21,6 +22,13 @@ from beman_tidy.lib.checks.beman_standard.readme import (
 test_data_prefix = "tests/lib/checks/beman_standard/readme/data"
 valid_prefix = f"{test_data_prefix}/valid"
 invalid_prefix = f"{test_data_prefix}/invalid"
+
+
+def test__readme_purpose__is_always_skipped(repo_info, beman_standard_check_config):
+    """
+    Test that readme.purpose is always skipped, as it cannot be implemented.
+    """
+    assert ReadmePurposeCheck(repo_info, beman_standard_check_config).should_skip()
 
 
 def test__readme_title__valid(repo_info, beman_standard_check_config):


### PR DESCRIPTION
Implemented readme.purpose - #50 

Note: readme.purpose can't be checked by beman-tidy, so it's skipped.