### PR TITLE
[beman-tidy] Make readme.implements more lenient

### DIFF
--- a/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
+++ b/tools/beman-tidy/beman_tidy/lib/checks/beman_standard/readme.py
@@ -117,9 +117,10 @@ class ReadmeImplementsCheck(ReadmeBaseCheck):
         # Match the pattern to start with "Implements:" and then have a paper reference and a wg21.link URL.
         # Examples of valid lines:
         # **Implements**: [Standard Library Concepts (P0898R3)](https://wg21.link/P0898R3).
+        # **Implements**: `std::ranges::any_view` proposed in [any_view (P3411)](https://wg21.link/p3411).
         # **Implements**: [Give *std::optional* Range Support (P3168R2)](https://wg21.link/P3168R2) and [`std::optional<T&>` (P2988R5)](https://wg21.link/P2988R5)
         # **Implements**: [.... (PxyzwRr)](https://wg21.link/PxyzwRr), [.... (PabcdRr)](https://wg21.link/PabcdRr), and [.... (PijklRr)](https://wg21.link/PijklRr),
-        regex = r"^\*\*Implements\*\*:\s+.*\bP\d{4}R\d+\b.*wg21\.link/\S+"
+        regex = r"^\*\*Implements\*\*:\s+.*\bP\d{4}R?\d*\b.*wg21\.link/\S+"
 
         # Count how many lines match the regex
         implement_lines = 0

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v5.md
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/data/valid/README-v5.md
@@ -1,0 +1,32 @@
+# beman.exemplar: A Beman Library Exemplar
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+<!-- markdownlint-disable-next-line line-length -->
+![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg) ![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg) ![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg) ![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+
+<!-- markdownlint-disable-next-line line-length -->
+`beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
+
+**Implements**: `std::ranges::any_view` proposed in [any_view (P3411)](https://wg21.link/p3411).
+
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
+
+## License
+
+This project is licensed under the Apache License 2.0 with LLVM Exceptions.
+
+## Other
+
+<!-- markdownlint-disable-next-line line-length -->
+This is a valid README.md file that follows the Beman Standard: the title is properly formatted with the library name and a short description.
+
+This is a valid README.md file that follows the Beman Standard: the badges are properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the purpose is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the implements is properly formatted - omits the paper's revision number.
+
+This is a valid README.md file that follows the Beman Standard: the library status is properly formatted.
+
+This is a valid README.md file that follows the Beman Standard: the license is properly formatted.

--- a/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
+++ b/tools/beman-tidy/tests/lib/checks/beman_standard/readme/test_readme.py
@@ -169,6 +169,7 @@ def test__readme_implements__valid(repo_info, beman_standard_check_config):
         Path(f"{valid_prefix}/README-v2.md"),
         Path(f"{valid_prefix}/README-v3.md"),
         Path(f"{valid_prefix}/README-v4.md"),
+        Path(f"{valid_prefix}/README-v5.md"),
     ]
 
     run_check_for_each_path(


### PR DESCRIPTION
Allow omitting the revision number from the "implements" line in the README.md.