### PR TITLE
Wrong content in debug string for use-fetch-content.cmake

### DIFF
--- a/cmake/use-fetch-content.cmake
+++ b/cmake/use-fetch-content.cmake
@@ -153,7 +153,8 @@ function(BemanExemplar_provideDependency method package_name)
                     BemanExemplar_debug
                     "Redirecting find_package calls for ${BemanExemplar_pkgName} "
                     "to FetchContent logic.\n"
-                    string
+                )
+                string(
                     APPEND
                     BemanExemplar_debug
                     "Fetching ${BemanExemplar_repo} at "


### PR DESCRIPTION
The `BemanExemplar_debug` string variable accidentally includes the literal string "string(APPEND BemanExemplar_debug" itself in the `BemanExemplar_debug` variable.