### PR TITLE
Fix beman-tidy workflow

### DIFF
--- a/.github/workflows/beman-tidy.yml
+++ b/.github/workflows/beman-tidy.yml
@@ -32,9 +32,6 @@ jobs:
 
   run_tests:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: tools/beman-tidy
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -52,9 +49,6 @@ jobs:
 
   build_and_install:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: tools/beman-tidy
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -75,9 +69,6 @@ jobs:
 
   run_on_exemplar:
     runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: tools/beman-tidy
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -105,4 +96,4 @@ jobs:
   create-issue-when-fault:
     needs: [run_linter, run_tests, build_and_install, run_on_exemplar]
     if: failure() && (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
-    uses: ./.github/workflows/reusable-beman-create-issue-when-fault.yml
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0


### PR DESCRIPTION
After beman-tidy was migrated out of the infra repository, 8deeb3aec13a43dcf8e4c064f295d33193900d22 attempted to restore the workflow file that ran its CI. Unfortunately, that workflow depended on a reusable workflow file that was no longer present. This commit addresses the issue by linking to the reusable workflow file as versioned in the infra-workflows repository, as is done by exemplar.

It also removes the working-directory parameter to reflect the directory reorganization performed during the migration.