### PR TITLE
fix: log padding && add blue for info logs

### DIFF
--- a/beman_tidy/lib/checks/base/base_check.py
+++ b/beman_tidy/lib/checks/base/base_check.py
@@ -9,6 +9,7 @@ from ...utils.string import (
     red_color,
     yellow_color,
     gray_color,
+    blue_color,
     no_color,
 )
 
@@ -172,7 +173,9 @@ class BaseCheck(ABC):
                 if log_level == "warning"
                 else gray_color
                 if log_level == "skipped"
+                else blue_color
+                if log_level == "info"
                 else no_color
             )
 
-            print(f"[{color}{log_level:<15}{no_color}][{self.name:<25}]: {message}")
+            print(f"[{color}{log_level}{no_color}][{self.name}]: {message}")

--- a/beman_tidy/lib/utils/string.py
+++ b/beman_tidy/lib/utils/string.py
@@ -6,6 +6,7 @@ import re
 red_color = "\033[91m"
 green_color = "\033[92m"
 yellow_color = "\033[93m"
+blue_color = "\033[94m"
 gray_color = "\033[90m"
 no_color = "\033[0m"
 


### PR DESCRIPTION
Fixes this log message padding issue.
before: 
    <img width="1840" height="104" alt="image" src="https://github.com/user-attachments/assets/b828c619-52fa-424c-9c21-dbecdd52b04b" />
after:
    <img width="1614" height="113" alt="image" src="https://github.com/user-attachments/assets/99b417d5-fa81-4c88-a8e0-481614cdc025" />

And, adds blue colouring for info logs
<img width="1171" height="118" alt="image" src="https://github.com/user-attachments/assets/8286c517-1205-44a5-af44-a05168449a5d" />

