### PR TITLE
feat: PyPI publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     steps:
       - name: Fetch artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v5
         with:
           name: dists
           path: dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,45 @@
+name: Build and Publish
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    name: Build Distributions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+
+      - name: uv build
+        run: uv build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dists
+          path: dist/
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Fetch artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dists
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -3,51 +3,12 @@
 <!--
 SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 -->
+`beman-tidy` is a tool aimed at Beman Project contributors to check (`--dry-run`)
+and apply (`--fix-inplace`) the [Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md)
+to their repositories.
 
-## Description
-
-`beman-tidy` is a tool used to check and apply
-[The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md).
-
-Purpose: The tool is used to `check` (`--dry-run`) and `apply` (`--fix-inplace`) the Beman Standard to a repository.
 Note: `2025-06-07`: In order to make the best and quickly use of the tool in the entire organization, most of the
 checks will not support the `--fix-inplace` flag in the first iteration.
-
-## Installation
-
-- The current recommended workflow relies on [Astral's uv](https://docs.astral.sh/uv/)
-- However, we provide a [PEP 751](https://peps.python.org/pep-0751/) `pylock.toml`, so don't feel forced to use uv
-- You can use beman-tidy as a pre-commit hook or install it on your system using `pipx`
-
-```shell
-uv build
-pipx install path/to/wheel
-```
-
-<details>
-<summary>beman-tidy: Full example - build and install</summary>
-
-```shell
-$ uv build
-Building source distribution...
-Building wheel from source distribution...
-Successfully built dist/beman_tidy-0.1.0.tar.gz
-Successfully built dist/beman_tidy-0.1.0-py3-none-any.whl
-
-$ pipx install dist/beman_tidy-0.1.0-py3-none-any.whl
-Installing to existing venv 'beman-tidy'
-  installed package beman-tidy 0.1.0, installed using Python 3.13.4
-  These apps are now globally available
-    - beman-tidy
-...
-You will need to open a new terminal or re-login for the PATH changes to take effect. Alternatively, you can source your shell's config file with e.g. 'source ~/.bashrc'.
-
-$ beman-tidy --help
-usage: beman-tidy [-h] [--fix-inplace | --no-fix-inplace] [--verbose | --no-verbose] [--checks CHECKS] repo_path
-...
-```
-
-</details>
 
 ## Usage
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -46,6 +46,20 @@ Check this PR example: [beman-tidy: add check - readme.library_status](https://g
 
 </details>
 
+## Build and Install from Source
+
+* The recommended workflow relies on [Astral's uv](https://docs.astral.sh/uv/)
+* To build:
+
+  ```shell
+  uv build
+  ```
+
+* To install:
+
+  ```shell
+  pipx install path/to/wheel
+  ```
 
 ## Linting
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,24 @@ requires-python = ">=3.12"
 authors = [{ name = "Darius Neațu", email = "neatudarius@gmail.com" }]
 maintainers = [{ name = "Rishyak", email = "hello@rishyak.com" }]
 dependencies = ["gitpython==3.1.44", "pyyaml==6.0.2"]
+keywords = [
+  "beman",
+  "bemanproject",
+  "linting",
+  "repository hygiene",
+  "compliance",
+  "beman standard",
+  "pre-commit tool",
+  "cli tool",
+  "automation",
+]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Environment :: Console",
+  "License :: OSI Approved :: Apache Software License",
+  "Programming Language :: Python :: 3",
+  "Intended Audience :: Developers",
+]
 
 [build-system]
 requires = ["flit_core >=3.2,<4"]


### PR DESCRIPTION
This is the long-awaited change to finally enable publishing beman-tidy to PyPI. 

### Usage
- Standard release engineering 
  - bump version in `pyproject.toml`
  - tag commit (don't forget to push the tag)
- Create a release on GitHub
  <img width="335" height="140" alt="image" src="https://github.com/user-attachments/assets/87b5007e-dfa8-4956-b683-469abf56a819" />
- Add details like the good release engineer you are
  <img width="1241" height="870" alt="image" src="https://github.com/user-attachments/assets/075acde0-582a-4b9a-9352-ee2a40f2d846" />
- Publish the release 
- The pipeline will automatically publish to PyPI

### Caveats
- I really recommend only one person does the release engineering for this
  - That being said, until we have the bemanproject PyPI org, I'll have to do this
  - So, I got it for now
  - Just email me (hello@rishyak.com) or ping me somehow, and I'll run up a release