### PR TITLE
chore: restore gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,19 @@
+# python
+__pycache__/
+.pytest_cache/
+*.pyc
+*.pyo
+*.pyd
+*.pyw
+*.pyz
+*.pywz
+*.pyzw
+*.pyzwz
+*.delete_me
+
+# macos
+*.DS_Store
+
+# editors
+.vscode/
+.idea/


### PR DESCRIPTION
The infra-bemantidy repository divorce unfortunately deleted the gitignore from this repo