### PR TITLE
Exclude `.git` directory from "directory.tests" check

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/directory.py
+++ b/beman_tidy/lib/checks/beman_standard/directory.py
@@ -115,7 +115,7 @@ class DirectoryTestsCheck(BemanTreeDirectoryCheck):
 
     def check(self):
         # Exclude directories that are not part of the tests.
-        exclude_dirs = [".github", "tests"]
+        exclude_dirs = [".github", "tests", ".git"]
         if self.repo_name == "exemplar":
             exclude_dirs.extend(["cookiecutter", "infra"])
 


### PR DESCRIPTION
Fixes #191 by adding the `.git` directory to `exclude_dirs`.

Rework of #195 to play nice with the repo reshuffling. 