### PR TITLE
[beman-tidy] Update directory.tests check

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/directory.py
+++ b/beman_tidy/lib/checks/beman_standard/directory.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import subprocess
+
 from ..base.directory_base_check import DirectoryBaseCheck
 from ..system.registry import register_beman_standard_check
 
@@ -115,13 +117,13 @@ class DirectoryTestsCheck(BemanTreeDirectoryCheck):
 
     def check(self):
         # Exclude directories that are not part of the tests.
-        exclude_dirs = [".github", "tests", ".git", "infra"]
+        exclude_dirs = [".github", f"tests/beman/{self.repo_info['name']}", ".git", "infra"]
         if self.repo_name == "exemplar":
-            exclude_dirs.extend("cookiecutter")
+            exclude_dirs.append("cookiecutter")
 
         # Find all test files in the repository outside the excluded directories.
         misplaced_test_files = []
-        for p in self.repo_path.rglob("*test*"):
+        for p in self.repo_path.rglob("*.test.*"):
             if not any(excluded in str(p) for excluded in exclude_dirs):
                 misplaced_test_files.append(p)
 
@@ -147,7 +149,7 @@ class DirectoryTestsCheck(BemanTreeDirectoryCheck):
             )
             return False
 
-        # Check passes if tests/ directory exists and contains relevant test files.
+        # Check passes if the tests/ directory exists and contains relevant test files.
         return True
 
     def fix(self):

--- a/beman_tidy/lib/checks/beman_standard/directory.py
+++ b/beman_tidy/lib/checks/beman_standard/directory.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import subprocess
-
 from ..base.directory_base_check import DirectoryBaseCheck
 from ..system.registry import register_beman_standard_check
 

--- a/tests/lib/checks/beman_standard/directory/data/invalid/repo-exemplar-v8/library/beman/exemplar/exemplar.cpp
+++ b/tests/lib/checks/beman_standard/directory/data/invalid/repo-exemplar-v8/library/beman/exemplar/exemplar.cpp
@@ -1,0 +1,1 @@
+// Dummy content, this file is used only for testing.

--- a/tests/lib/checks/beman_standard/directory/data/invalid/repo-exemplar-v8/tests/beman/exemplar/CMakeLists.txt
+++ b/tests/lib/checks/beman_standard/directory/data/invalid/repo-exemplar-v8/tests/beman/exemplar/CMakeLists.txt
@@ -1,0 +1,1 @@
+# Dummy content

--- a/tests/lib/checks/beman_standard/directory/data/invalid/repo-exemplar-v8/tests/beman/exemplar/identity.test.cpp
+++ b/tests/lib/checks/beman_standard/directory/data/invalid/repo-exemplar-v8/tests/beman/exemplar/identity.test.cpp
@@ -1,0 +1,1 @@
+// Dummy content

--- a/tests/lib/checks/beman_standard/directory/data/invalid/repo-exemplar-v8/tests/beman/identity.test.cpp
+++ b/tests/lib/checks/beman_standard/directory/data/invalid/repo-exemplar-v8/tests/beman/identity.test.cpp
@@ -1,0 +1,1 @@
+// Dummy content

--- a/tests/lib/checks/beman_standard/directory/test_directory.py
+++ b/tests/lib/checks/beman_standard/directory/test_directory.py
@@ -118,6 +118,8 @@ def test__directory_tests__invalid(repo_info, beman_standard_check_config):
         Path(f"{invalid_prefix}/repo-exemplar-v6"),
         # Wrong name for tests/ directory.
         Path(f"{invalid_prefix}/repo-exemplar-v7"),
+        # Test file in tests/beman/ directory with a test file in tests/beman/<short_name>.
+        Path(f"{invalid_prefix}/repo-exemplar-v8"),
     ]
 
     run_check_for_each_path(


### PR DESCRIPTION
Solved issue - #189 
Updated rglob pattern to check for anything that contains *.test.* instead of *test*

Updated directory.tests check:
- Updated excluded_dirs to exclude tests/beman/<short_name>, not only tests/ (added 1 unit test for this)
- Fixed rglob pattern