### PR TITLE
Implemented a config file for beman-tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,30 +143,23 @@ beman-tidy path/to/exemplar --fix-inplace --verbose
 
 ## Configuration
 
-You can configure `beman-tidy` by placing a `.beman-tidy.yml` file in the root of your repository.
+`beman-tidy` attempts to read configuration for each source file from a `.beman-tidy.yml` file located in the root of your repository. You can also specify a custom configuration file path using the `--config` option.
 
-Currently, it supports ignoring specific paths or directories. When you add a path to `ignored_paths`, it will be excluded from all checks.
+The following configuration options may be used in a `.beman-tidy.yml` file:
 
-- To ignore a specific file, provide its full path relative to the repository root.
-- To ignore a directory, provide the path to that directory. This will ignore the directory itself and all files and subdirectories within it. A trailing slash (`/`) is optional.
+`ignored_paths` - A list of paths to be excluded from all checks.
+  - To ignore a specific file, provide its full path relative to the repository root.
+  - To ignore a directory, provide the path to that directory. This will ignore the directory itself and all files and subdirectories within it. A trailing slash (`/`) is optional.
 
-For example:
-```yaml
-ignored_paths:
-  - include/beman/optional/detail/stl_interfaces/config.hpp
-  - include/beman/optional/detail/stl_interfaces/
-```
-or
-```yaml
-ignored_paths:
-  - include/beman/optional/detail/stl_interfaces/
-```
-
-You can also specify a custom configuration file path using the `--config` option:
-
-```shell
-beman-tidy . --config my-config.yml
-```
+  Example:
+  ```yaml
+  ignored_paths:
+    # Ignores a single file
+    - include/beman/optional/detail/stl_interfaces/config.hpp
+    
+    # Ignores a directory and everything inside it
+    - include/beman/optional/another_dir
+  ```
 
 ## Working on beman-tidy
 

--- a/README.md
+++ b/README.md
@@ -145,11 +145,20 @@ beman-tidy path/to/exemplar --fix-inplace --verbose
 
 You can configure `beman-tidy` by placing a `.beman-tidy.yml` file in the root of your repository.
 
-Currently, it supports ignoring specific paths or directories:
+Currently, it supports ignoring specific paths or directories. When you add a path to `ignored_paths`, it will be excluded from all checks.
 
+- To ignore a specific file, provide its full path relative to the repository root.
+- To ignore a directory, provide the path to that directory. This will ignore the directory itself and all files and subdirectories within it. A trailing slash (`/`) is optional.
+
+For example:
 ```yaml
 ignored_paths:
   - include/beman/optional/detail/stl_interfaces/config.hpp
+  - include/beman/optional/detail/stl_interfaces/
+```
+or
+```yaml
+ignored_paths:
   - include/beman/optional/detail/stl_interfaces/
 ```
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ expedite adoption across the Beman Project.
 
 ```shell
 $ beman-tidy --help
-usage: beman-tidy [-h] [--fix-inplace | --no-fix-inplace] [--verbose | --no-verbose] [--require-all | --no-require-all] [--checks CHECKS] repo_path
+usage: beman-tidy [-h] [--fix-inplace | --no-fix-inplace] [--verbose | --no-verbose] [--require-all | --no-require-all] [--checks CHECKS] [--config CONFIG] repo_path
 
 positional arguments:
   repo_path             path to the repository to check
@@ -33,6 +33,7 @@ options:
   --require-all, --no-require-all
                         all checks are required regardless of the check type (e.g., Recommendation becomes Requirement)
   --checks CHECKS       array of checks to run
+  --config CONFIG       path to the configuration file (default: .beman-tidy.yml in repo root)
 ```
 
 - Run beman-tidy on the exemplar repository **(default: dry-run mode)**
@@ -138,6 +139,24 @@ Coverage          TOTAL:  95.83% (23/24 checks passed).
 
 ```shell
 beman-tidy path/to/exemplar --fix-inplace --verbose
+```
+
+## Configuration
+
+You can configure `beman-tidy` by placing a `.beman-tidy.yml` file in the root of your repository.
+
+Currently, it supports ignoring specific paths or directories:
+
+```yaml
+ignored_paths:
+  - include/beman/optional/detail/stl_interfaces/config.hpp
+  - include/beman/optional/detail/stl_interfaces/
+```
+
+You can also specify a custom configuration file path using the `--config` option:
+
+```shell
+beman-tidy . --config my-config.yml
 ```
 
 ## Working on beman-tidy

--- a/beman_tidy/.beman-tidy.yml
+++ b/beman_tidy/.beman-tidy.yml
@@ -1,0 +1,1 @@
+# Default beman-tidy configuration

--- a/beman_tidy/.beman-tidy.yml
+++ b/beman_tidy/.beman-tidy.yml
@@ -1,1 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
 # Default beman-tidy configuration

--- a/beman_tidy/cli.py
+++ b/beman_tidy/cli.py
@@ -17,7 +17,7 @@ def parse_args():
     parser.add_argument("repo_path", help="path to the repository to check", type=str)
     parser.add_argument(
         "--fix-inplace",
-        help="Try to automatically fix found issues",
+        help="try to automatically fix found issues",
         action=argparse.BooleanOptionalAction,
         default=False,
     )
@@ -36,9 +36,12 @@ def parse_args():
     parser.add_argument(
         "--checks", help="array of checks to run", type=str, default=None
     )
+    parser.add_argument(
+        "--config", help="path to the configuration file (default: .beman-tidy.yml in repo root)", type=str, default=None
+    )
     args = parser.parse_args()
 
-    args.repo_info = get_repo_info(args.repo_path)
+    args.repo_info = get_repo_info(args.repo_path, config_path=args.config)
     args.checks = args.checks.split(",") if args.checks else None
 
     return args

--- a/beman_tidy/lib/checks/base/base_check.py
+++ b/beman_tidy/lib/checks/base/base_check.py
@@ -65,16 +65,6 @@ class BaseCheck(ABC):
         )
         assert self.full_text_body is not None
 
-        # set log level - e.g. "error" or "warning" or "skipped"
-        self.log_enabled = False
-        self.log_level = (
-            "skipped"
-            if self.should_skip()
-            else "error"
-            if self.type == "Requirement"
-            else "warning"
-        )
-
         # set repo info
         self.repo_info = repo_info
         assert "name" in repo_info
@@ -94,6 +84,25 @@ class BaseCheck(ABC):
         assert "values" in beman_library_maturity_model
         assert len(beman_library_maturity_model["values"]) == 4
         self.beman_library_maturity_model = beman_library_maturity_model["values"]
+
+        self.log_enabled = False
+        self._log_level = None  # lazily initialized
+
+    @property
+    def log_level(self):
+        if self._log_level is None:
+            self._log_level = (
+                "skipped"
+                if self.should_skip()
+                else "error"
+                if self.type == "Requirement"
+                else "warning"
+            )
+        return self._log_level
+
+    @log_level.setter
+    def log_level(self, value):
+        self._log_level = value
 
     def should_skip(self):
         """

--- a/beman_tidy/lib/checks/base/base_check.py
+++ b/beman_tidy/lib/checks/base/base_check.py
@@ -87,17 +87,22 @@ class BaseCheck(ABC):
 
         self.log_enabled = False
         self._log_level = None  # lazily initialized
+        self._is_resolving_log_level = False
 
     @property
     def log_level(self):
         if self._log_level is None:
-            self._log_level = (
-                "skipped"
-                if self.should_skip()
-                else "error"
-                if self.type == "Requirement"
-                else "warning"
-            )
+            self._is_resolving_log_level = True
+            try:
+                self._log_level = (
+                    "skipped"
+                    if self.should_skip()
+                    else "error"
+                    if self.type == "Requirement"
+                    else "warning"
+                )
+            finally:
+                self._is_resolving_log_level = False
         return self._log_level
 
     @log_level.setter
@@ -176,17 +181,23 @@ class BaseCheck(ABC):
         """
 
         if self.log_enabled and enabled:
-            log_level = log_level if log_level else self.log_level
+            if log_level:
+                level = log_level
+            elif self._is_resolving_log_level: # if it hasn't been initialized yet
+                level = "info"
+            else:
+                level = self.log_level
+
             color = (
                 red_color
-                if log_level == "error"
+                if level == "error"
                 else yellow_color
-                if log_level == "warning"
+                if level == "warning"
                 else gray_color
-                if log_level == "skipped"
+                if level == "skipped"
                 else blue_color
-                if log_level == "info"
+                if level == "info"
                 else no_color
             )
 
-            print(f"[{color}{log_level}{no_color}][{self.name}]: {message}")
+            print(f"[{color}{level}{no_color}][{self.name}]: {message}")

--- a/beman_tidy/lib/checks/base/directory_base_check.py
+++ b/beman_tidy/lib/checks/base/directory_base_check.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from beman_tidy.lib.utils.string import normalize_path_for_display
 
 from .base_check import BaseCheck
-from ...utils.config import get_ignores
+from ...utils.config import is_ignored
 
 
 class DirectoryBaseCheck(BaseCheck):
@@ -52,20 +52,7 @@ class DirectoryBaseCheck(BaseCheck):
         """
         if super().should_skip():
             return True
-
-        ignores = get_ignores(self.repo_info)
-        rel_path_str = self.relative_path.as_posix()
-        for ignore in ignores:
-            ignore_str = str(ignore)
-            if rel_path_str == ignore_str:
-                return True
-            if ignore_str.endswith("/"):
-                if rel_path_str.startswith(ignore_str):
-                    return True
-            elif rel_path_str.startswith(ignore_str + "/"):
-                return True
-
-        return False
+        return is_ignored(self.repo_info, self.relative_path)
 
     @abstractmethod
     def check(self):

--- a/beman_tidy/lib/checks/base/directory_base_check.py
+++ b/beman_tidy/lib/checks/base/directory_base_check.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from beman_tidy.lib.utils.string import normalize_path_for_display
 
 from .base_check import BaseCheck
+from ...utils.config import get_ignores
 
 
 class DirectoryBaseCheck(BaseCheck):
@@ -16,6 +17,7 @@ class DirectoryBaseCheck(BaseCheck):
 
     def __init__(self, repo_info, beman_standard_check_config, relative_path):
         super().__init__(repo_info, beman_standard_check_config)
+        self.relative_path = Path(relative_path)
 
         # set path - e.g. "src/beman/exemplar"
         self.path = self.repo_path / relative_path
@@ -43,6 +45,27 @@ class DirectoryBaseCheck(BaseCheck):
             return False
 
         return True
+
+    def should_skip(self):
+        """
+        Check if the file should be skipped based on configuration.
+        """
+        if super().should_skip():
+            return True
+
+        ignores = get_ignores(self.repo_info)
+        rel_path_str = self.relative_path.as_posix()
+        for ignore in ignores:
+            ignore_str = str(ignore)
+            if rel_path_str == ignore_str:
+                return True
+            if ignore_str.endswith("/"):
+                if rel_path_str.startswith(ignore_str):
+                    return True
+            elif rel_path_str.startswith(ignore_str + "/"):
+                return True
+
+        return False
 
     @abstractmethod
     def check(self):

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -16,10 +16,11 @@ class FileBaseCheck(BaseCheck):
     """
 
     def __init__(self, repo_info, beman_standard_check_config, relative_path, name=None):
+        self.repo_info = repo_info
+        self.relative_path = Path(relative_path)
         super().__init__(repo_info, beman_standard_check_config, name=name)
 
         # set path - e.g. "README.md"
-        self.relative_path = Path(relative_path)
         self.path = self.repo_path / relative_path
 
     def pre_check(self):

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -16,6 +16,7 @@ class FileBaseCheck(BaseCheck):
     """
 
     def __init__(self, repo_info, beman_standard_check_config, relative_path, name=None):
+        self.repo_info = repo_info
         self.relative_path = Path(relative_path)
         super().__init__(repo_info, beman_standard_check_config, name=name)
 

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -4,9 +4,9 @@
 from abc import abstractmethod
 import re
 
-from beman_tidy.lib.utils.string import normalize_path_for_display
-
 from .base_check import BaseCheck
+from ...utils.file import get_cpp_files, get_repo_ignorable_subdirectories
+
 
 class FileBaseCheck(BaseCheck):
     """
@@ -32,13 +32,11 @@ class FileBaseCheck(BaseCheck):
             return False
 
         if not self.path.exists():
-            display_path = normalize_path_for_display(self.path, self.repo_path)
-            self.log(f"The file '{display_path}' does not exist.")
+            self.log(f"The file '{self.path}' does not exist.")
             return False
 
         if self.is_empty():
-            display_path = normalize_path_for_display(self.path, self.repo_path)
-            self.log(f"The file '{display_path}' is empty.")
+            self.log(f"The file '{self.path}' is empty.")
             return False
 
         return True
@@ -91,8 +89,7 @@ class FileBaseCheck(BaseCheck):
             with open(self.path, "w") as file:
                 file.write(content)
         except Exception as e:
-            display_path = normalize_path_for_display(self.path, self.repo_path)
-            self.log(f"Error writing the file '{display_path}': {e}")
+            self.log(f"Error writing the file '{self.path}': {e}")
 
     def write_lines(self, lines):
         """
@@ -174,7 +171,11 @@ class BatchFileBaseCheck(BaseCheck):
         """
         self._validate()
 
-        source_files = self.file_path_generator(self.repo_path)
+        system_ignores = get_repo_ignorable_subdirectories()
+        user_ignores = self.repo_info.get("config", {}).get("ignored_paths", [])
+        ignores = list(system_ignores) + user_ignores
+
+        source_files = self.file_path_generator(self.repo_path, ignores=ignores)
         all_successful = True
         
         for relative_path in source_files:

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -16,6 +16,7 @@ class FileBaseCheck(BaseCheck):
     """
 
     def __init__(self, repo_info, beman_standard_check_config, relative_path, name=None):
+        self.repo_info = repo_info
         super().__init__(repo_info, beman_standard_check_config, name=name)
 
         # set path - e.g. "README.md"

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -4,6 +4,7 @@
 from abc import abstractmethod
 import re
 
+from beman_tidy.lib.utils.string import normalize_path_for_display
 from .base_check import BaseCheck
 from ...utils.file import get_repo_ignorable_subdirectories
 
@@ -32,11 +33,13 @@ class FileBaseCheck(BaseCheck):
             return False
 
         if not self.path.exists():
-            self.log(f"The file '{self.path}' does not exist.")
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+            self.log(f"The file '{display_path}' does not exist.")
             return False
 
         if self.is_empty():
-            self.log(f"The file '{self.path}' is empty.")
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+            self.log(f"The file '{display_path}' is empty.")
             return False
 
         return True
@@ -89,7 +92,8 @@ class FileBaseCheck(BaseCheck):
             with open(self.path, "w") as file:
                 file.write(content)
         except Exception as e:
-            self.log(f"Error writing the file '{self.path}': {e}")
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+            self.log(f"Error writing the file '{display_path}': {e}")
 
     def write_lines(self, lines):
         """
@@ -171,9 +175,9 @@ class BatchFileBaseCheck(BaseCheck):
         """
         self._validate()
 
-        system_ignores = get_repo_ignorable_subdirectories()
+        default_ignores = get_repo_ignorable_subdirectories()
         user_ignores = self.repo_info.get("config", {}).get("ignored_paths", [])
-        ignores = list(system_ignores) + user_ignores
+        ignores = list(default_ignores) + user_ignores
 
         source_files = self.file_path_generator(self.repo_path, ignores=ignores)
         all_successful = True

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -55,9 +55,7 @@ class FileBaseCheck(BaseCheck):
             return True
 
         ignores = get_ignores(self.repo_info)
-
         rel_path_str = self.relative_path.as_posix()
-
         for ignore in ignores:
             ignore_str = str(ignore)
             if rel_path_str == ignore_str:

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -16,7 +16,6 @@ class FileBaseCheck(BaseCheck):
     """
 
     def __init__(self, repo_info, beman_standard_check_config, relative_path, name=None):
-        self.repo_info = repo_info
         self.relative_path = Path(relative_path)
         super().__init__(repo_info, beman_standard_check_config, name=name)
 

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -16,9 +16,8 @@ class FileBaseCheck(BaseCheck):
     """
 
     def __init__(self, repo_info, beman_standard_check_config, relative_path, name=None):
-        self.repo_info = repo_info
-        self.relative_path = Path(relative_path)
         super().__init__(repo_info, beman_standard_check_config, name=name)
+        self.relative_path = Path(relative_path)
 
         # set path - e.g. "README.md"
         self.path = self.repo_path / relative_path
@@ -181,7 +180,6 @@ class BatchFileBaseCheck(BaseCheck):
         file_check.name = self.name
 
         file_check.log_enabled = self.log_enabled
-        file_check.log_level = self.log_level
         
         if file_check.should_skip():
             return None

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from beman_tidy.lib.utils.string import normalize_path_for_display
 from .base_check import BaseCheck
-from ...utils.file import get_repo_ignorable_subdirectories
+from ...utils.config import get_ignores
 
 
 class FileBaseCheck(BaseCheck):
@@ -53,9 +53,7 @@ class FileBaseCheck(BaseCheck):
         if super().should_skip():
             return True
 
-        default_ignores = get_repo_ignorable_subdirectories()
-        user_ignores = self.repo_info.get("config", {}).get("ignored_paths", [])
-        ignores = list(default_ignores) + user_ignores
+        ignores = get_ignores(self.repo_info)
 
         rel_path_str = self.relative_path.as_posix()
 
@@ -202,9 +200,7 @@ class BatchFileBaseCheck(BaseCheck):
         """
         self._validate()
 
-        default_ignores = get_repo_ignorable_subdirectories()
-        user_ignores = self.repo_info.get("config", {}).get("ignored_paths", [])
-        ignores = list(default_ignores) + user_ignores
+        ignores = get_ignores(self.repo_info)
 
         all_files = self.file_path_generator(self.repo_path, ignores=ignores)
         all_successful = True

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -3,6 +3,7 @@
 
 from abc import abstractmethod
 import re
+from pathlib import Path
 
 from beman_tidy.lib.utils.string import normalize_path_for_display
 from .base_check import BaseCheck
@@ -18,6 +19,7 @@ class FileBaseCheck(BaseCheck):
         super().__init__(repo_info, beman_standard_check_config, name=name)
 
         # set path - e.g. "README.md"
+        self.relative_path = Path(relative_path)
         self.path = self.repo_path / relative_path
 
     def pre_check(self):
@@ -43,6 +45,31 @@ class FileBaseCheck(BaseCheck):
             return False
 
         return True
+
+    def should_skip(self):
+        """
+        Check if the file should be skipped based on configuration.
+        """
+        if super().should_skip():
+            return True
+
+        default_ignores = get_repo_ignorable_subdirectories()
+        user_ignores = self.repo_info.get("config", {}).get("ignored_paths", [])
+        ignores = list(default_ignores) + user_ignores
+
+        rel_path_str = self.relative_path.as_posix()
+
+        for ignore in ignores:
+            ignore_str = str(ignore)
+            if rel_path_str == ignore_str:
+                return True
+            if ignore_str.endswith("/"):
+                if rel_path_str.startswith(ignore_str):
+                    return True
+            elif rel_path_str.startswith(ignore_str + "/"):
+                return True
+
+        return False
 
     @abstractmethod
     def check(self):

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -5,7 +5,7 @@ from abc import abstractmethod
 import re
 
 from .base_check import BaseCheck
-from ...utils.file import get_cpp_files, get_repo_ignorable_subdirectories
+from ...utils.file import get_repo_ignorable_subdirectories
 
 
 class FileBaseCheck(BaseCheck):

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from beman_tidy.lib.utils.string import normalize_path_for_display
 from .base_check import BaseCheck
-from ...utils.config import get_ignores
+from ...utils.config import is_ignored, get_ignores
 
 
 class FileBaseCheck(BaseCheck):
@@ -52,20 +52,7 @@ class FileBaseCheck(BaseCheck):
         """
         if super().should_skip():
             return True
-
-        ignores = get_ignores(self.repo_info)
-        rel_path_str = self.relative_path.as_posix()
-        for ignore in ignores:
-            ignore_str = str(ignore)
-            if rel_path_str == ignore_str:
-                return True
-            if ignore_str.endswith("/"):
-                if rel_path_str.startswith(ignore_str):
-                    return True
-            elif rel_path_str.startswith(ignore_str + "/"):
-                return True
-
-        return False
+        return is_ignored(self.repo_info, self.relative_path)
 
     @abstractmethod
     def check(self):

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -4,6 +4,7 @@
 from abc import abstractmethod
 import re
 
+from beman_tidy.lib.utils.string import normalize_path_for_display
 from .base_check import BaseCheck
 from ...utils.file import get_repo_ignorable_subdirectories
 
@@ -32,11 +33,13 @@ class FileBaseCheck(BaseCheck):
             return False
 
         if not self.path.exists():
-            self.log(f"The file '{self.path}' does not exist.")
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+            self.log(f"The file '{display_path}' does not exist.")
             return False
 
         if self.is_empty():
-            self.log(f"The file '{self.path}' is empty.")
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+            self.log(f"The file '{display_path}' is empty.")
             return False
 
         return True
@@ -89,7 +92,8 @@ class FileBaseCheck(BaseCheck):
             with open(self.path, "w") as file:
                 file.write(content)
         except Exception as e:
-            self.log(f"Error writing the file '{self.path}': {e}")
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+            self.log(f"Error writing the file '{display_path}': {e}")
 
     def write_lines(self, lines):
         """
@@ -171,14 +175,14 @@ class BatchFileBaseCheck(BaseCheck):
         """
         self._validate()
 
-        system_ignores = get_repo_ignorable_subdirectories()
+        default_ignores = get_repo_ignorable_subdirectories()
         user_ignores = self.repo_info.get("config", {}).get("ignored_paths", [])
-        ignores = list(system_ignores) + user_ignores
+        ignores = list(default_ignores) + user_ignores
 
-        source_files = self.file_path_generator(self.repo_path, ignores=ignores)
+        all_files = self.file_path_generator(self.repo_path, ignores=ignores)
         all_successful = True
         
-        for relative_path in source_files:
+        for relative_path in all_files:
             file_check = self._create_and_init_file_check(relative_path)
 
             if file_check is None:

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -4,6 +4,7 @@
 import sys
 import yaml
 from pathlib import Path
+from importlib.resources import files
 from beman_tidy.lib.utils.file import get_repo_ignorable_subdirectories
 
 
@@ -46,31 +47,38 @@ def load_repo_config(repo_path, config_path=None):
     """
     Load the configuration file.
     """
+    # Load default configuration
+    default_config_path = files('beman_tidy').joinpath('.beman-tidy.yml')
+    with default_config_path.open('r') as f:
+        default_config = yaml.safe_load(f) or {}
+
+    # Determine user config path
     if config_path:
-        target_path = Path(config_path)
+        user_config_path = Path(config_path)
     else:
-        target_path = Path(repo_path) / ".beman-tidy.yml" # default name
+        user_config_path = Path(repo_path) / ".beman-tidy.yml"
 
-    if not target_path.exists():
-        if config_path:
-            print(f"Error: Configuration file specified not found at '{config_path}'")
+    # Load user configuration if it exists
+    user_config = {}
+    if user_config_path.exists():
+        try:
+            with open(user_config_path, "r") as f:
+                user_config = yaml.safe_load(f) or {}
+        except Exception as e:
+            print(f"Error loading user configuration from '{user_config_path}': {e}")
             sys.exit(1)
-        return {}
-
-    try:
-        with open(target_path, "r") as f:
-            config = yaml.safe_load(f)
-    except Exception as e:
-        print(f"Error loading configuration from '{target_path}': {e}")
+    elif config_path:
+        print(f"Error: Configuration file specified not found at '{config_path}'")
         sys.exit(1)
 
-    if config is None:
-        return {}
+    # Merge configurations
+    merged_config = default_config.copy()
+    merged_config.update(user_config)
 
-    if not validate_config(config):
+    if not validate_config(merged_config):
         sys.exit(1)
 
-    return config
+    return merged_config
 
 
 def get_ignores(repo_info):

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -4,7 +4,6 @@
 import sys
 import yaml
 from pathlib import Path
-from importlib.resources import files
 from beman_tidy.lib.utils.file import get_repo_ignorable_subdirectories
 
 
@@ -43,12 +42,19 @@ def validate_config(config):
     return True
 
 
+def get_default_config_path():
+    """
+    Returns the path to the default configuration file.
+    """
+    return Path(__file__).parent.parent.parent / ".beman-standard.yml"
+
+
 def load_repo_config(repo_path, config_path=None):
     """
     Load the configuration file.
     """
     # Load default configuration
-    default_config_path = files('beman_tidy').joinpath('.beman-tidy.yml')
+    default_config_path = get_default_config_path()
     with default_config_path.open('r') as f:
         default_config = yaml.safe_load(f) or {}
 

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -34,7 +34,7 @@ def validate_config(config):
         
         # Check if ignoring root directory
         if path == "." or path == "./":
-             print(f"Error: Cannot ignore root directory in .beman-tidy.yml")
+             print("Error: Cannot ignore root directory in .beman-tidy.yml")
              return False
              
     return True

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -70,3 +70,14 @@ def load_repo_config(repo_path, config_path=None):
         sys.exit(1)
 
     return config
+
+
+def get_ignores(repo_info):
+    """
+    Returns a combined list of default system ignores and user-configured ignores.
+    """
+    from beman_tidy.lib.utils.file import get_repo_ignorable_subdirectories
+
+    default_ignores = get_repo_ignorable_subdirectories()
+    user_ignores = repo_info.get("config", {}).get("ignored_paths", [])
+    return list(default_ignores) + user_ignores

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -89,3 +89,21 @@ def get_ignores(repo_info):
     default_ignores = get_repo_ignorable_subdirectories()
     user_ignores = repo_info.get("config", {}).get("ignored_paths", [])
     return list(default_ignores) + user_ignores
+
+
+def is_ignored(repo_info, relative_path):
+    """
+    Check if a given path is ignored by the configuration.
+    """
+    ignores = get_ignores(repo_info)
+    rel_path_str = relative_path.as_posix()
+    for ignore in ignores:
+        ignore_str = str(ignore)
+        if rel_path_str == ignore_str:
+            return True
+        if ignore_str.endswith("/"):
+            if rel_path_str.startswith(ignore_str):
+                return True
+        elif rel_path_str.startswith(ignore_str + "/"):
+            return True
+    return False

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -27,13 +27,14 @@ def validate_config(config):
             print(f"Error: Invalid entry in 'ignored_paths': {path}. Must be a string.")
             return False
 
+        clean_path = path.rstrip("/")
         # Check for exact match
-        if path in mandatory_files:
-             print(f"Error: Cannot ignore mandatory file '{path}' in .beman-tidy.yml")
+        if clean_path in mandatory_files:
+             print(f"Error: Cannot ignore mandatory file '{clean_path}' in .beman-tidy.yml")
              return False
         
         # Check if ignoring root directory
-        if path == "." or path == "./":
+        if clean_path == "." or clean_path == "":
              print("Error: Cannot ignore root directory in .beman-tidy.yml")
              return False
              

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
+import yaml
+from pathlib import Path
+
+
+def validate_config(config):
+    """
+    Validate the repository configuration.
+    Ensures mandatory files are not ignored.
+    Returns True if valid, False otherwise.
+    """
+    ignored_paths = config.get("ignored_paths", [])
+    if not ignored_paths:
+        return True
+
+    if not isinstance(ignored_paths, list):
+        print(f"Error: 'ignored_paths' in .beman-tidy.yml must be a list, but got {type(ignored_paths).__name__}.")
+        return False
+
+    mandatory_files = {"README.md", "LICENSE"}
+
+    for path in ignored_paths:
+        if not isinstance(path, str):
+            print(f"Error: Invalid entry in 'ignored_paths': {path}. Must be a string.")
+            return False
+
+        # Check for exact match
+        if path in mandatory_files:
+             print(f"Error: Cannot ignore mandatory file '{path}' in .beman-tidy.yml")
+             return False
+        
+        # Check if ignoring root directory
+        if path == "." or path == "./":
+             print(f"Error: Cannot ignore root directory in .beman-tidy.yml")
+             return False
+             
+    return True
+
+
+def load_repo_config(repo_path, config_path=None):
+    """
+    Load the configuration file.
+    """
+    if config_path:
+        target_path = Path(config_path)
+    else:
+        target_path = Path(repo_path) / ".beman-tidy.yml" # default name
+
+    if not target_path.exists():
+        if config_path:
+            print(f"Error: Configuration file specified not found at '{config_path}'")
+            sys.exit(1)
+        return {}
+
+    try:
+        with open(target_path, "r") as f:
+            config = yaml.safe_load(f)
+    except Exception as e:
+        print(f"Error loading configuration from '{target_path}': {e}")
+        sys.exit(1)
+
+    if config is None:
+        return {}
+
+    if not validate_config(config):
+        sys.exit(1)
+
+    return config

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -94,16 +94,18 @@ def get_ignores(repo_info):
 def is_ignored(repo_info, relative_path):
     """
     Check if a given path is ignored by the configuration.
+    A path can be a file or a directory.
+    If a directory is ignored, all its children are also ignored.
     """
     ignores = get_ignores(repo_info)
     rel_path_str = relative_path.as_posix()
     for ignore in ignores:
-        ignore_str = str(ignore)
+        ignore_str = str(ignore).rstrip('/')
+
         if rel_path_str == ignore_str:
             return True
-        if ignore_str.endswith("/"):
-            if rel_path_str.startswith(ignore_str):
-                return True
-        elif rel_path_str.startswith(ignore_str + "/"):
+        
+        if rel_path_str.startswith(ignore_str + '/'):
             return True
+
     return False

--- a/beman_tidy/lib/utils/file.py
+++ b/beman_tidy/lib/utils/file.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import os
 from pathlib import Path
 
 
@@ -8,7 +9,7 @@ def get_repo_ignorable_subdirectories():
     """
     Returns a set of common build and IDE directories to ignore.
     """
-    return {".git", "build", ".idea", ".vscode", "__pycache__", "venv", "env"}
+    return {".git/", "build/", ".idea/", ".vscode/", "__pycache__/", "venv/", "env/"}
 
 
 def get_cpp_extensions():
@@ -18,42 +19,49 @@ def get_cpp_extensions():
     return {".hpp", ".h", ".hxx", ".hh", ".cpp", ".cxx", ".cc", ".c"}
 
 
-def get_matched_paths(repo_path, extensions, exclude_dirs=None):
+def _is_ignored(path, ignores):
+    path_str = path.as_posix()
+
+    for pattern in ignores:
+        clean_pattern = pattern.rstrip("/") # trailing slash is optional
+        if path_str == clean_pattern or path_str.startswith(clean_pattern + "/"):
+            return True
+    return False
+
+
+def get_matched_paths(repo_path, extensions, ignores=None):
     """
     Get all files in the repository matching the given extensions.
-    Ignores directories specified in exclude_dirs.
+    Ignores paths specified in 'ignores'.
     """
-    if exclude_dirs is None:
-        exclude_dirs = get_repo_ignorable_subdirectories()
+    if ignores is None:
+        ignores = get_repo_ignorable_subdirectories()
 
     matched_files = []
     repo_path = Path(repo_path)
 
-    for path in repo_path.rglob("*"):
-        if not path.is_file():
-            continue
+    for root, dirs, files in os.walk(repo_path):
+        rel_root = Path(root).relative_to(repo_path)
 
-        try:
-            relative_path = path.relative_to(repo_path)
-        except ValueError:
-            continue
+        for d in list(dirs):
+            d_path = rel_root / d
+            if _is_ignored(d_path, ignores):
+                dirs.remove(d)
 
-        # Check if any part of the relative path is in exclude_dirs
-        if any(part in exclude_dirs for part in relative_path.parts):
-            continue
-
-        # Found match.
-        if path.suffix in extensions:
-            matched_files.append(relative_path)
+        for f in files:
+            f_path = rel_root / f
+            if f_path.suffix in extensions:
+                if not _is_ignored(f_path, ignores):
+                    matched_files.append(f_path)
 
     return sorted(list(set(matched_files)))
 
 
-def get_cpp_files(repo_path):
+def get_cpp_files(repo_path, ignores=None):
     """
     Get all C++ source and header files in the repository.
     """
-    return get_matched_paths(repo_path, get_cpp_extensions())
+    return get_matched_paths(repo_path, get_cpp_extensions(), ignores=ignores)
 
 
 def get_spdx_info(lines):

--- a/beman_tidy/lib/utils/git.py
+++ b/beman_tidy/lib/utils/git.py
@@ -7,6 +7,7 @@ import yaml
 from pathlib import Path
 
 from git import Repo, InvalidGitRepositoryError
+from .config import load_repo_config
 
 
 def parse_repo_name_from_remote_url(remote_url: str) -> str | None:
@@ -46,7 +47,7 @@ def parse_repo_name_from_remote_url(remote_url: str) -> str | None:
     return None
 
 
-def get_repo_info(path: str):
+def get_repo_info(path: str, config_path: str = None):
     """
     Get information about the repository at the given path.
     Returns data as a dictionary.
@@ -99,6 +100,9 @@ def get_repo_info(path: str):
         # Get unstaged changes
         unstaged_changes = repo.git.diff("--stat")
 
+        # Load repository configuration
+        config = load_repo_config(top_level_dir, config_path)
+
         return {
             "top_level": top_level_dir,
             "name": repo_name,  # Keep for backward compatibility (checkout directory name)
@@ -109,6 +113,7 @@ def get_repo_info(path: str):
             "commit_hash": commit_hash,
             "status": status,
             "unstaged_changes": unstaged_changes,
+            "config": config,
         }
     except InvalidGitRepositoryError:
         print(f"The path '{path}' is not inside a valid Git repository.")

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -13,6 +13,7 @@
 * `tests/`: Unit tests for the tool.
   * Structure is similar to the `beman_tidy/` directory.
   * `pytest` is used for testing.
+* `.beman-tidy.yml`: Configuration file for `beman-tidy` (optional).
 
 ## Adding a new check
 

--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -10,10 +10,10 @@
     * `beman_tidy/lib/checks/`: The checks for the tool.
     * `beman_tidy/lib/pipeline.py`: The checks pipeline for the `beman-tidy` tool.
   * `beman_tidy/.beman-standard.yml`: Stable (offline) version of the standard.
+  * `beman_tidy/.beman-tidy.yml`: Default configuration file for `beman-tidy`. Will be merged with the user's.
 * `tests/`: Unit tests for the tool.
   * Structure is similar to the `beman_tidy/` directory.
   * `pytest` is used for testing.
-* `.beman-tidy.yml`: Configuration file for `beman-tidy` (optional).
 
 ## Adding a new check
 

--- a/tests/lib/utils/conftest.py
+++ b/tests/lib/utils/conftest.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+
+from tests.utils.conftest import mock_repo_info, mock_beman_standard_check_config  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def repo_info(mock_repo_info):  # noqa: F811
+    return mock_repo_info
+
+
+@pytest.fixture(autouse=True)
+def beman_standard_check_config(mock_beman_standard_check_config):  # noqa: F811
+    return mock_beman_standard_check_config

--- a/tests/lib/utils/test_config.py
+++ b/tests/lib/utils/test_config.py
@@ -3,7 +3,7 @@
 
 import pytest
 import yaml
-from beman_tidy.lib.utils.config import validate_config, load_repo_config
+from beman_tidy.lib.utils.config import validate_config, load_repo_config, get_default_config_path
 
 def test_validate_config_valid():
     """Test that a valid configuration passes validation."""
@@ -68,33 +68,49 @@ def test_validate_config_root_ignored(capsys):
     assert "Error: Cannot ignore root directory" in captured.out
 
 def test_load_repo_config_default(tmp_path):
-    """Test loading the default configuration file."""
-    config_content = {
+    """Test loading the default configuration file and merging with user config."""
+    default_config_path = get_default_config_path()
+    with default_config_path.open('r') as f:
+        expected_config = yaml.safe_load(f) or {}
+
+    user_config_content = {
         "ignored_paths": ["build/"]
     }
+    expected_config.update(user_config_content)
+
     config_file = tmp_path / ".beman-tidy.yml"
     with open(config_file, "w") as f:
-        yaml.dump(config_content, f)
+        yaml.dump(user_config_content, f)
 
     config = load_repo_config(tmp_path)
-    assert config == config_content
+    assert config == expected_config
 
 def test_load_repo_config_custom_path(tmp_path):
     """Test loading a configuration file from a custom path."""
-    config_content = {
+    default_config_path = get_default_config_path()
+    with default_config_path.open('r') as f:
+        expected_config = yaml.safe_load(f) or {}
+
+    user_config_content = {
         "ignored_paths": ["dist/"]
     }
+    expected_config.update(user_config_content)
+    
     config_file = tmp_path / "custom_config.yml"
     with open(config_file, "w") as f:
-        yaml.dump(config_content, f)
+        yaml.dump(user_config_content, f)
 
     config = load_repo_config(tmp_path, config_path=str(config_file))
-    assert config == config_content
+    assert config == expected_config
 
 def test_load_repo_config_not_found_default(tmp_path):
     """Test loading when the default configuration file does not exist."""
+    default_config_path = get_default_config_path()
+    with default_config_path.open('r') as f:
+        expected_config = yaml.safe_load(f) or {}
+    
     config = load_repo_config(tmp_path)
-    assert config == {}
+    assert config == expected_config
 
 def test_load_repo_config_not_found_custom(tmp_path, capsys):
     """Test loading when a custom configuration file does not exist."""

--- a/tests/lib/utils/test_config.py
+++ b/tests/lib/utils/test_config.py
@@ -3,8 +3,6 @@
 
 import pytest
 import yaml
-import sys
-from pathlib import Path
 from beman_tidy.lib.utils.config import validate_config, load_repo_config
 
 def test_validate_config_valid():

--- a/tests/lib/utils/test_config.py
+++ b/tests/lib/utils/test_config.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+import yaml
+import sys
+from pathlib import Path
+from beman_tidy.lib.utils.config import validate_config, load_repo_config
+
+def test_validate_config_valid():
+    """Test that a valid configuration passes validation."""
+    config = {
+        "ignored_paths": ["build/", ".git/"]
+    }
+    assert validate_config(config) is True
+
+def test_validate_config_empty():
+    """Test that an empty configuration passes validation."""
+    config = {}
+    assert validate_config(config) is True
+
+def test_validate_config_ignored_paths_not_list(capsys):
+    """Test that validation fails if ignored_paths is not a list."""
+    config = {
+        "ignored_paths": "not a list"
+    }
+    assert validate_config(config) is False
+    captured = capsys.readouterr()
+    assert "Error: 'ignored_paths' in .beman-tidy.yml must be a list" in captured.out
+
+def test_validate_config_ignored_paths_invalid_entry(capsys):
+    """Test that validation fails if ignored_paths contains non-string entries."""
+    config = {
+        "ignored_paths": [123]
+    }
+    assert validate_config(config) is False
+    captured = capsys.readouterr()
+    assert "Error: Invalid entry in 'ignored_paths'" in captured.out
+
+def test_validate_config_mandatory_file_ignored(capsys):
+    """Test that validation fails if a mandatory file is ignored."""
+    config = {
+        "ignored_paths": ["README.md"]
+    }
+    assert validate_config(config) is False
+    captured = capsys.readouterr()
+    assert "Error: Cannot ignore mandatory file 'README.md'" in captured.out
+
+    config = {
+        "ignored_paths": ["LICENSE"]
+    }
+    assert validate_config(config) is False
+    captured = capsys.readouterr()
+    assert "Error: Cannot ignore mandatory file 'LICENSE'" in captured.out
+
+def test_validate_config_root_ignored(capsys):
+    """Test that validation fails if the root directory is ignored."""
+    config = {
+        "ignored_paths": ["."]
+    }
+    assert validate_config(config) is False
+    captured = capsys.readouterr()
+    assert "Error: Cannot ignore root directory" in captured.out
+
+    config = {
+        "ignored_paths": ["./"]
+    }
+    assert validate_config(config) is False
+    captured = capsys.readouterr()
+    assert "Error: Cannot ignore root directory" in captured.out
+
+def test_load_repo_config_default(tmp_path):
+    """Test loading the default configuration file."""
+    config_content = {
+        "ignored_paths": ["build/"]
+    }
+    config_file = tmp_path / ".beman-tidy.yml"
+    with open(config_file, "w") as f:
+        yaml.dump(config_content, f)
+
+    config = load_repo_config(tmp_path)
+    assert config == config_content
+
+def test_load_repo_config_custom_path(tmp_path):
+    """Test loading a configuration file from a custom path."""
+    config_content = {
+        "ignored_paths": ["dist/"]
+    }
+    config_file = tmp_path / "custom_config.yml"
+    with open(config_file, "w") as f:
+        yaml.dump(config_content, f)
+
+    config = load_repo_config(tmp_path, config_path=str(config_file))
+    assert config == config_content
+
+def test_load_repo_config_not_found_default(tmp_path):
+    """Test loading when the default configuration file does not exist."""
+    config = load_repo_config(tmp_path)
+    assert config == {}
+
+def test_load_repo_config_not_found_custom(tmp_path, capsys):
+    """Test loading when a custom configuration file does not exist."""
+    with pytest.raises(SystemExit):
+        load_repo_config(tmp_path, config_path=str(tmp_path / "nonexistent.yml"))
+    
+    captured = capsys.readouterr()
+    assert "Error: Configuration file specified not found" in captured.out
+
+def test_load_repo_config_invalid_yaml(tmp_path, capsys):
+    """Test loading an invalid YAML file."""
+    config_file = tmp_path / ".beman-tidy.yml"
+    with open(config_file, "w") as f:
+        f.write("invalid: yaml: :")
+
+    with pytest.raises(SystemExit):
+        load_repo_config(tmp_path)
+    
+    captured = capsys.readouterr()
+    assert "Error loading configuration" in captured.out
+
+def test_load_repo_config_invalid_validation(tmp_path, capsys):
+    """Test loading a configuration that fails validation."""
+    config_content = {
+        "ignored_paths": ["README.md"]
+    }
+    config_file = tmp_path / ".beman-tidy.yml"
+    with open(config_file, "w") as f:
+        yaml.dump(config_content, f)
+
+    with pytest.raises(SystemExit):
+        load_repo_config(tmp_path)
+    
+    captured = capsys.readouterr()
+    assert "Error: Cannot ignore mandatory file 'README.md'" in captured.out

--- a/tests/lib/utils/test_config.py
+++ b/tests/lib/utils/test_config.py
@@ -114,7 +114,7 @@ def test_load_repo_config_invalid_yaml(tmp_path, capsys):
         load_repo_config(tmp_path)
     
     captured = capsys.readouterr()
-    assert "Error loading configuration" in captured.out
+    assert "Error loading user configuration" in captured.out
 
 def test_load_repo_config_invalid_validation(tmp_path, capsys):
     """Test loading a configuration that fails validation."""


### PR DESCRIPTION
#227
Initial implementation:
- Load config with default name, `.beman-tidy.yml`, or `config_path` param.
- In the config yaml content, the entry `ignored_paths:` is used specify paths of dirs or files. Dirs exclude all files and dirs in them. (behaves like gitignore)
- Previously excluded dirs (.idea etc.) are now merged with this functionality in the `ignores` param found on `get_*_files()` functions.
- introduced `is_ignored()` function in `lib/utils/file.py` to check if a given path is ignored