### PR TITLE
Implemented block comment support for file.copyright checks

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -3,7 +3,7 @@
 
 from ..base.file_base_check import FileBaseCheck, BatchFileBaseCheck
 from ..system.registry import register_beman_standard_check
-from ...utils.file import get_cpp_files, get_spdx_type
+from ...utils.file import get_cpp_files, get_spdx_info
 from ...utils.comments import find_in_comment, CommentType, BLOCK_ENDS, BLOCK_STARTS, LINE_PREFIXES
 
 # [file.*] checks category.
@@ -26,8 +26,8 @@ class FileCopyrightCheck(BatchFileBaseCheck):
     Recommendation: Source code files should NOT include a copyright notice following the SPDX license identifier.
     """
 
-    def __init__(self, repo_type, beman_standard_check_config):
-        super().__init__(repo_type, beman_standard_check_config)
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
         self.file_check_class = self.FileCopyrightCheckImpl
         self.file_path_generator = get_cpp_files
 
@@ -35,29 +35,29 @@ class FileCopyrightCheck(BatchFileBaseCheck):
         """
         Implementation the "file.copyright" check for a single file.
         """
-        def __init__(self, repo_type, beman_standard_check_config, relative_path):
-            super().__init__(repo_type, beman_standard_check_config, relative_path, name="file.copyright")
+        def __init__(self, repo_info, beman_standard_check_config, relative_path):
+            super().__init__(repo_info, beman_standard_check_config, relative_path, name="file.copyright")
 
         def check(self):
             lines = self.read_lines()
-            spdx_index, comment_type = get_spdx_type(lines)
+            spdx_index, comment_info = get_spdx_info(lines)
 
-            if not self._has_valid_spdx(spdx_index, comment_type):
+            if not self._has_valid_spdx(spdx_index, comment_info):
                 return True
 
             start_search_index = spdx_index + 1
-            search_comment_type = comment_type
+            search_comment_info = comment_info
 
-            if self._is_single_line_block_comment(lines, spdx_index, comment_type):
-                next_index, next_type = self._find_next_comment_start(lines, spdx_index + 1)
+            if self._is_single_line_block_comment(lines, spdx_index, comment_info):
+                next_index, next_info = self._find_next_comment_start(lines, spdx_index + 1)
                 if next_index != -1:
                     start_search_index = next_index
-                    search_comment_type = next_type
+                    search_comment_info = next_info
                 else:
                     return True
 
             # Start searching from the line after SPDX identifier
-            line_index, found_text = find_in_comment(lines, start_search_index, search_comment_type, ["copyright", "(c)"], ignore_case=True)
+            line_index, found_text = find_in_comment(lines, start_search_index, search_comment_info, ["copyright", "(c)"], ignore_case=True)
             
             if line_index is not None:
                 self.log(f"Copyright notice found in {self.path.name} at line {line_index+1}. It should be removed.")
@@ -67,19 +67,19 @@ class FileCopyrightCheck(BatchFileBaseCheck):
 
         def fix(self):
             lines = self.read_lines()
-            spdx_index, comment_type = get_spdx_type(lines)
+            spdx_index, comment_info = get_spdx_info(lines)
 
-            if not self._has_valid_spdx(spdx_index, comment_type):
+            if not self._has_valid_spdx(spdx_index, comment_info):
                 return True
 
             start_fix_index = spdx_index + 1
-            fix_comment_type = comment_type
+            fix_comment_info = comment_info
 
-            if self._is_single_line_block_comment(lines, spdx_index, comment_type):
+            if self._is_single_line_block_comment(lines, spdx_index, comment_info):
                 next_index, next_style = self._find_next_comment_start(lines, spdx_index + 1)
                 if next_index != -1:
                     start_fix_index = next_index
-                    fix_comment_type = next_style
+                    fix_comment_info = next_style
                 else:
                     return True
 
@@ -87,7 +87,7 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             new_lines = self._remove_lines_with_text_in_comment(
                 lines, 
                 start_fix_index,
-                fix_comment_type, 
+                fix_comment_info,
                 ["copyright", "(c)"], 
                 log_func=lambda msg: self.log(f"{msg} in {self.path.name}")
             )
@@ -95,11 +95,11 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             self.write("".join(new_lines))
             return True
 
-        def _has_valid_spdx(self, spdx_index, comment_type):
-            return spdx_index != -1 and comment_type is not None
+        def _has_valid_spdx(self, spdx_index, comment_info):
+            return spdx_index != -1 and comment_info is not None
 
-        def _is_single_line_block_comment(self, lines, spdx_index, comment_type):
-            if comment_type == CommentType.BLOCK:
+        def _is_single_line_block_comment(self, lines, spdx_index, comment_info):
+            if comment_info == CommentType.BLOCK:
                 if any(end in lines[spdx_index] for end in BLOCK_ENDS):
                     return True
             return False
@@ -121,22 +121,22 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             
             return -1, None
 
-        def _remove_lines_with_text_in_comment(self, lines, start_index, comment_type, texts, log_func=None):
+        def _remove_lines_with_text_in_comment(self, lines, start_index, comment_info, texts, log_func=None):
             """
             Removes lines from the comment block that contain any of the texts.
             Preserves block comment structure.
             Returns the new list of lines.
             """
-            if start_index < 0 or start_index >= len(lines) or comment_type is None:
+            if start_index < 0 or start_index >= len(lines) or comment_info is None:
                 return lines
 
             new_lines = lines[:start_index]
             
-            if comment_type == CommentType.LINE:
+            if comment_info == CommentType.LINE:
                 processed_lines, next_index = self._process_line_comments(lines, start_index, texts, log_func)
                 new_lines.extend(processed_lines)
                 new_lines.extend(lines[next_index:])
-            elif comment_type == CommentType.BLOCK:
+            elif comment_info == CommentType.BLOCK:
                 processed_lines, next_index = self._process_block_comments(lines, start_index, texts, log_func)
                 new_lines.extend(processed_lines)
                 new_lines.extend(lines[next_index:])

--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -3,7 +3,7 @@
 
 from ..base.file_base_check import FileBaseCheck, BatchFileBaseCheck
 from ..system.registry import register_beman_standard_check
-from ...utils.file import get_cpp_files, get_spdx_info
+from ...utils.file import get_cpp_files, get_spdx_type
 from ...utils.comments import find_in_comment, CommentType, BLOCK_ENDS, BLOCK_STARTS, LINE_PREFIXES
 
 # [file.*] checks category.
@@ -26,8 +26,8 @@ class FileCopyrightCheck(BatchFileBaseCheck):
     Recommendation: Source code files should NOT include a copyright notice following the SPDX license identifier.
     """
 
-    def __init__(self, repo_info, beman_standard_check_config):
-        super().__init__(repo_info, beman_standard_check_config)
+    def __init__(self, repo_type, beman_standard_check_config):
+        super().__init__(repo_type, beman_standard_check_config)
         self.file_check_class = self.FileCopyrightCheckImpl
         self.file_path_generator = get_cpp_files
 
@@ -35,46 +35,91 @@ class FileCopyrightCheck(BatchFileBaseCheck):
         """
         Implementation the "file.copyright" check for a single file.
         """
-        def __init__(self, repo_info, beman_standard_check_config, relative_path):
-            super().__init__(repo_info, beman_standard_check_config, relative_path, name="file.copyright")
+        def __init__(self, repo_type, beman_standard_check_config, relative_path):
+            super().__init__(repo_type, beman_standard_check_config, relative_path, name="file.copyright")
 
         def check(self):
             lines = self.read_lines()
-            spdx_index, comment_info = get_spdx_info(lines)
+            spdx_index, comment_type = get_spdx_type(lines)
 
-            if spdx_index == -1:
+            if not self._has_valid_spdx(spdx_index, comment_type):
                 return True
-            
-            if comment_info is None:
-                return True
+
+            start_search_index = spdx_index + 1
+            search_comment_type = comment_type
+
+            if self._is_single_line_block_comment(lines, spdx_index, comment_type):
+                next_index, next_type = self._find_next_comment_start(lines, spdx_index + 1)
+                if next_index != -1:
+                    start_search_index = next_index
+                    search_comment_type = next_type
+                else:
+                    return True
 
             # Start searching from the line after SPDX identifier
-            line_idx, found_text = find_in_comment(lines, spdx_index + 1, comment_info, ["copyright", "(c)"], ignore_case=True)
+            line_index, found_text = find_in_comment(lines, start_search_index, search_comment_type, ["copyright", "(c)"], ignore_case=True)
             
-            if line_idx is not None:
-                self.log(f"Copyright notice found in {self.path.name} at line {line_idx+1}. It should be removed.")
+            if line_index is not None:
+                self.log(f"Copyright notice found in {self.path.name} at line {line_index+1}. It should be removed.")
                 return False
 
             return True
 
         def fix(self):
             lines = self.read_lines()
-            spdx_index, comment_info = get_spdx_info(lines)
+            spdx_index, comment_type = get_spdx_type(lines)
 
-            if spdx_index == -1 or comment_info is None:
+            if not self._has_valid_spdx(spdx_index, comment_type):
                 return True
+
+            start_fix_index = spdx_index + 1
+            fix_comment_type = comment_type
+
+            if self._is_single_line_block_comment(lines, spdx_index, comment_type):
+                next_index, next_style = self._find_next_comment_start(lines, spdx_index + 1)
+                if next_index != -1:
+                    start_fix_index = next_index
+                    fix_comment_type = next_style
+                else:
+                    return True
 
             # Start removing from the line after SPDX identifier
             new_lines = self._remove_lines_with_text_in_comment(
                 lines, 
-                spdx_index + 1,
-                comment_info, 
+                start_fix_index,
+                fix_comment_type, 
                 ["copyright", "(c)"], 
                 log_func=lambda msg: self.log(f"{msg} in {self.path.name}")
             )
 
             self.write("".join(new_lines))
             return True
+
+        def _has_valid_spdx(self, spdx_index, comment_type):
+            return spdx_index != -1 and comment_type is not None
+
+        def _is_single_line_block_comment(self, lines, spdx_index, comment_type):
+            if comment_type == CommentType.BLOCK:
+                if any(end in lines[spdx_index] for end in BLOCK_ENDS):
+                    return True
+            return False
+
+        def _find_next_comment_start(self, lines, start_index):
+            for i in range(start_index, len(lines)):
+                line = lines[i].strip()
+                if not line:
+                    continue
+                
+                if any(line.startswith(prefix) for prefix in LINE_PREFIXES):
+                    return i, CommentType.LINE
+                
+                if any(line.startswith(start) for start in BLOCK_STARTS):
+                    return i, CommentType.BLOCK
+                
+                # Found non-comment code
+                return -1, None
+            
+            return -1, None
 
         def _remove_lines_with_text_in_comment(self, lines, start_index, comment_type, texts, log_func=None):
             """
@@ -88,13 +133,13 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             new_lines = lines[:start_index]
             
             if comment_type == CommentType.LINE:
-                processed_lines, next_idx = self._process_line_comments(lines, start_index, texts, log_func)
+                processed_lines, next_index = self._process_line_comments(lines, start_index, texts, log_func)
                 new_lines.extend(processed_lines)
-                new_lines.extend(lines[next_idx:])
+                new_lines.extend(lines[next_index:])
             elif comment_type == CommentType.BLOCK:
-                processed_lines, next_idx = self._process_block_comments(lines, start_index, texts, log_func)
+                processed_lines, next_index = self._process_block_comments(lines, start_index, texts, log_func)
                 new_lines.extend(processed_lines)
-                new_lines.extend(lines[next_idx:])
+                new_lines.extend(lines[next_index:])
             else:
                 new_lines.extend(lines[start_index:])
             
@@ -143,7 +188,8 @@ class FileCopyrightCheck(BatchFileBaseCheck):
                 
                 if block_end:
                     new_line = self._handle_block_end_line(line, texts, block_end, log_func)
-                    processed_lines.append(new_line)
+                    if new_line is not None:
+                        processed_lines.append(new_line)
                     i += 1
                     break
                 
@@ -186,8 +232,13 @@ class FileCopyrightCheck(BatchFileBaseCheck):
                     break
             
             if block_start:
-                 start_idx = pre.find(block_start)
-                 new_line_content += pre[:start_idx + len(block_start)] + " "
+                 start_index = pre.find(block_start)
+                 
+                 # Check if we can remove the line entirely
+                 if not pre[:start_index].strip() and not post.strip():
+                     return None
+
+                 new_line_content += pre[:start_index + len(block_start)] + " "
             else:
                  stripped_pre = pre.strip()
                  if stripped_pre.startswith("*"):

--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -59,36 +59,139 @@ class FileCopyrightCheck(BatchFileBaseCheck):
 
         def fix(self):
             lines = self.read_lines()
-            spdx_index, comment_prefix = get_spdx_info(lines)
+            spdx_index, comment_info = get_spdx_info(lines)
 
-            if spdx_index == -1 or comment_prefix is None:
+            if spdx_index == -1 or comment_info is None:
                 return True
 
-            new_lines = []
-            new_lines.extend(lines[:spdx_index+1])
+            # Start removing from the line after SPDX identifier
+            new_lines = self._remove_lines_with_text_in_comment(
+                lines, 
+                spdx_index + 1,
+                comment_info, 
+                ["copyright", "(c)"], 
+                log_func=lambda msg: self.log(f"{msg} in {self.path.name}")
+            )
+
+            self.write("".join(new_lines))
+            return True
+
+        def _remove_lines_with_text_in_comment(self, lines, start_index, comment_type, texts, log_func=None):
+            """
+            Removes lines from the comment block that contain any of the texts.
+            Preserves block comment structure.
+            Returns the new list of lines.
+            """
+            if start_index < 0 or start_index >= len(lines) or comment_type is None:
+                return lines
+
+            new_lines = lines[:start_index]
             
-            i = spdx_index + 1
+            if comment_type == CommentType.LINE:
+                processed_lines, next_idx = self._process_line_comments(lines, start_index, texts, log_func)
+                new_lines.extend(processed_lines)
+                new_lines.extend(lines[next_idx:])
+            elif comment_type == CommentType.BLOCK:
+                processed_lines, next_idx = self._process_block_comments(lines, start_index, texts, log_func)
+                new_lines.extend(processed_lines)
+                new_lines.extend(lines[next_idx:])
+            else:
+                new_lines.extend(lines[start_index:])
+            
+            return new_lines
+
+        def _process_line_comments(self, lines, start_index, texts, log_func):
+            processed_lines = []
+            i = start_index
+            prefix = '//' # Hardcoded as per comments.py logic
+            
             while i < len(lines):
                 line = lines[i]
                 stripped = line.strip()
                 
                 if not stripped:
-                    new_lines.append(line)
+                    processed_lines.append(line)
                     i += 1
                     continue
                     
-                if not stripped.startswith(comment_prefix):
-                    new_lines.extend(lines[i:])
+                if not stripped.startswith(prefix):
                     break
                 
-                lower_line = stripped.lower()
-                if "copyright" in lower_line or "(c)" in lower_line:
-                    self.log(f"Removing copyright line in {self.path.name}: {stripped}")
+                if self._contains_text(stripped, texts):
+                    if log_func:
+                        log_func(f"Removing line: {stripped}")
                     i += 1
                     continue
                 
-                new_lines.append(line)
+                processed_lines.append(line)
+                i += 1
+            
+            return processed_lines, i
+
+        def _process_block_comments(self, lines, start_index, texts, log_func):
+            processed_lines = []
+            i = start_index
+            block_start = BLOCK_START
+            block_end = BLOCK_END
+            
+            while i < len(lines):
+                line = lines[i]
+                stripped = line.strip()
+                
+                if block_end in line:
+                    new_line = self._handle_block_end_line(line, texts, block_start, block_end, log_func)
+                    processed_lines.append(new_line)
+                    i += 1
+                    break
+                
+                # Normal block line
+                if self._contains_text(stripped, texts):
+                    if log_func:
+                        log_func(f"Removing line: {stripped}")
+                    i += 1
+                    continue
+                    
+                processed_lines.append(line)
                 i += 1
                 
-            self.write_lines(new_lines)
-            return True
+            return processed_lines, i
+
+        def _handle_block_end_line(self, line, texts, block_start, block_end, log_func):
+            pre, sep, post = line.partition(block_end)
+            lower_pre = pre.lower()
+            
+            found_text = None
+            for text in texts:
+                if text.lower() in lower_pre:
+                    found_text = text
+                    break
+            
+            if found_text:
+                if log_func:
+                    log_func(f"Removing line content: {line.strip()}")
+                return self._reconstruct_block_end_line(pre, sep, post, block_start)
+            
+            return line
+
+        def _reconstruct_block_end_line(self, pre, sep, post, block_start):
+            new_line_content = ""
+            if block_start in pre:
+                 start_idx = pre.find(block_start)
+                 new_line_content += pre[:start_idx + len(block_start)] + " "
+            else:
+                 stripped_pre = pre.strip()
+                 if stripped_pre.startswith("*"):
+                     indent = pre[:pre.find("*")+1]
+                     new_line_content += indent + " "
+                 else:
+                     new_line_content += pre[:len(pre)-len(pre.lstrip())]
+            
+            new_line_content += sep + post
+            return new_line_content
+
+        def _contains_text(self, line, texts):
+            lower_line = line.lower()
+            for text in texts:
+                if text.lower() in lower_line:
+                    return True
+            return False

--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -38,27 +38,37 @@ class FileCopyrightCheck(BatchFileBaseCheck):
         def __init__(self, repo_info, beman_standard_check_config, relative_path):
             super().__init__(repo_info, beman_standard_check_config, relative_path, name="file.copyright")
 
-        def check(self):
-            lines = self.read_lines()
+        def _get_copyright_search_start_info(self, lines):
+            """
+            Finds the starting point for searching for copyright notices.
+            This is the comment block immediately following the SPDX identifier.
+            Returns (start_index, comment_type) or (None, None) if no further processing is needed.
+            """
             spdx_index, comment_type = get_spdx_info(lines)
-
             if not self._has_valid_spdx(spdx_index, comment_type):
-                return True
+                return None, None
 
-            start_search_index = spdx_index + 1
+            start_index = spdx_index + 1
             search_comment_type = comment_type
-
             if self._is_single_line_block_comment(lines, spdx_index, comment_type):
                 next_index, next_comment_type = self._find_next_comment_start(lines, spdx_index + 1)
                 if next_index != -1:
-                    start_search_index = next_index
+                    start_index = next_index
                     search_comment_type = next_comment_type
                 else:
-                    return True
+                    return None, None
+
+            return start_index, search_comment_type
+
+        def check(self):
+            lines = self.read_lines()
+            start_search_index, search_comment_type = self._get_copyright_search_start_info(lines)
+            if start_search_index is None:
+                return True
 
             # Start searching from the line after SPDX identifier
             line_index, found_text = find_in_comment(lines, start_search_index, search_comment_type, ["copyright", "(c)"], ignore_case=True)
-            
+
             if line_index is not None:
                 self.log(f"Copyright notice found in {self.path.name} at line {line_index+1}. It should be removed.")
                 return False
@@ -67,28 +77,16 @@ class FileCopyrightCheck(BatchFileBaseCheck):
 
         def fix(self):
             lines = self.read_lines()
-            spdx_index, comment_type = get_spdx_info(lines)
-
-            if not self._has_valid_spdx(spdx_index, comment_type):
+            start_fix_index, fix_comment_type = self._get_copyright_search_start_info(lines)
+            if start_fix_index is None:
                 return True
-
-            start_fix_index = spdx_index + 1
-            fix_comment_type = comment_type
-
-            if self._is_single_line_block_comment(lines, spdx_index, comment_type):
-                next_index, next_comment_type = self._find_next_comment_start(lines, spdx_index + 1)
-                if next_index != -1:
-                    start_fix_index = next_index
-                    fix_comment_type = next_comment_type
-                else:
-                    return True
 
             # Start removing from the line after SPDX identifier
             new_lines = self._remove_lines_with_text_in_comment(
-                lines, 
+                lines,
                 start_fix_index,
                 fix_comment_type,
-                ["copyright", "(c)"], 
+                ["copyright", "(c)"],
                 log_func=lambda msg: self.log(f"{msg} in {self.path.name}")
             )
 
@@ -131,7 +129,6 @@ class FileCopyrightCheck(BatchFileBaseCheck):
                 return lines
 
             new_lines = lines[:start_index]
-            
             if comment_type == CommentType.LINE:
                 processed_lines, next_index = self._process_line_comments(lines, start_index, texts, log_func)
                 new_lines.extend(processed_lines)
@@ -152,15 +149,12 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             while i < len(lines):
                 line = lines[i]
                 stripped = line.strip()
-                
                 if not stripped:
                     processed_lines.append(line)
                     i += 1
                     continue
-                    
                 if not any(stripped.startswith(prefix) for prefix in LINE_PREFIXES):
                     break
-                
                 if self._contains_text(stripped, texts):
                     if log_func:
                         log_func(f"Removing line: {stripped}")

--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -4,6 +4,7 @@
 from ..base.file_base_check import FileBaseCheck, BatchFileBaseCheck
 from ..system.registry import register_beman_standard_check
 from ...utils.file import get_cpp_files, get_spdx_info
+from ...utils.comments import find_in_comment, CommentType, BLOCK_END, BLOCK_START
 
 # [file.*] checks category.
 # All checks in this file extend the BaseCheck class.
@@ -39,31 +40,21 @@ class FileCopyrightCheck(BatchFileBaseCheck):
 
         def check(self):
             lines = self.read_lines()
-            spdx_index, comment_prefix = get_spdx_info(lines)
+            spdx_index, comment_info = get_spdx_info(lines)
 
             if spdx_index == -1:
                 return True
             
-            if comment_prefix is None:
-                # TODO: Support block comments (e.g. Markdown <!-- ... --> or C++ /* ... */)
+            if comment_info is None:
                 return True
 
-            for i in range(spdx_index + 1, len(lines)):
-                line = lines[i].strip()
-                
-                # Allows empty lines
-                if not line:
-                    continue
-                    
-                # If it doesn't start with comment prefix, assumes end of header comments
-                if not line.startswith(comment_prefix):
-                    break
-                
-                lower_line = line.lower()
-                if "copyright" in lower_line or "(c)" in lower_line:
-                    self.log(f"Copyright notice found in {self.path.name} at line {i+1}. It should be removed.")
-                    return False
-                    
+            # Start searching from the line after SPDX identifier
+            line_idx, found_text = find_in_comment(lines, spdx_index + 1, comment_info, ["copyright", "(c)"], ignore_case=True)
+            
+            if line_idx is not None:
+                self.log(f"Copyright notice found in {self.path.name} at line {line_idx+1}. It should be removed.")
+                return False
+
             return True
 
         def fix(self):

--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -3,7 +3,7 @@
 
 from ..base.file_base_check import FileBaseCheck, BatchFileBaseCheck
 from ..system.registry import register_beman_standard_check
-from ...utils.file import get_cpp_files, get_spdx_type
+from ...utils.file import get_cpp_files, get_spdx_info
 from ...utils.comments import find_in_comment, CommentType, BLOCK_ENDS, BLOCK_STARTS, LINE_PREFIXES
 
 # [file.*] checks category.
@@ -26,8 +26,8 @@ class FileCopyrightCheck(BatchFileBaseCheck):
     Recommendation: Source code files should NOT include a copyright notice following the SPDX license identifier.
     """
 
-    def __init__(self, repo_type, beman_standard_check_config):
-        super().__init__(repo_type, beman_standard_check_config)
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
         self.file_check_class = self.FileCopyrightCheckImpl
         self.file_path_generator = get_cpp_files
 
@@ -35,12 +35,12 @@ class FileCopyrightCheck(BatchFileBaseCheck):
         """
         Implementation the "file.copyright" check for a single file.
         """
-        def __init__(self, repo_type, beman_standard_check_config, relative_path):
-            super().__init__(repo_type, beman_standard_check_config, relative_path, name="file.copyright")
+        def __init__(self, repo_info, beman_standard_check_config, relative_path):
+            super().__init__(repo_info, beman_standard_check_config, relative_path, name="file.copyright")
 
         def check(self):
             lines = self.read_lines()
-            spdx_index, comment_type = get_spdx_type(lines)
+            spdx_index, comment_type = get_spdx_info(lines)
 
             if not self._has_valid_spdx(spdx_index, comment_type):
                 return True
@@ -49,10 +49,10 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             search_comment_type = comment_type
 
             if self._is_single_line_block_comment(lines, spdx_index, comment_type):
-                next_index, next_type = self._find_next_comment_start(lines, spdx_index + 1)
+                next_index, next_comment_type = self._find_next_comment_start(lines, spdx_index + 1)
                 if next_index != -1:
                     start_search_index = next_index
-                    search_comment_type = next_type
+                    search_comment_type = next_comment_type
                 else:
                     return True
 
@@ -67,7 +67,7 @@ class FileCopyrightCheck(BatchFileBaseCheck):
 
         def fix(self):
             lines = self.read_lines()
-            spdx_index, comment_type = get_spdx_type(lines)
+            spdx_index, comment_type = get_spdx_info(lines)
 
             if not self._has_valid_spdx(spdx_index, comment_type):
                 return True
@@ -76,10 +76,10 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             fix_comment_type = comment_type
 
             if self._is_single_line_block_comment(lines, spdx_index, comment_type):
-                next_index, next_style = self._find_next_comment_start(lines, spdx_index + 1)
+                next_index, next_type = self._find_next_comment_start(lines, spdx_index + 1)
                 if next_index != -1:
                     start_fix_index = next_index
-                    fix_comment_type = next_style
+                    fix_comment_type = next_type
                 else:
                     return True
 
@@ -87,7 +87,7 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             new_lines = self._remove_lines_with_text_in_comment(
                 lines, 
                 start_fix_index,
-                fix_comment_type, 
+                fix_comment_type,
                 ["copyright", "(c)"], 
                 log_func=lambda msg: self.log(f"{msg} in {self.path.name}")
             )
@@ -95,8 +95,8 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             self.write("".join(new_lines))
             return True
 
-        def _has_valid_spdx(self, spdx_index, comment_type):
-            return spdx_index != -1 and comment_type is not None
+        def _has_valid_spdx(self, spdx_index, type):
+            return spdx_index != -1 and type is not None
 
         def _is_single_line_block_comment(self, lines, spdx_index, comment_type):
             if comment_type == CommentType.BLOCK:

--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -4,7 +4,7 @@
 from ..base.file_base_check import FileBaseCheck, BatchFileBaseCheck
 from ..system.registry import register_beman_standard_check
 from ...utils.file import get_cpp_files, get_spdx_info
-from ...utils.comments import find_in_comment, CommentType, BLOCK_END, BLOCK_START
+from ...utils.comments import find_in_comment, CommentType, BLOCK_ENDS, BLOCK_STARTS, LINE_PREFIXES
 
 # [file.*] checks category.
 # All checks in this file extend the BaseCheck class.
@@ -103,7 +103,6 @@ class FileCopyrightCheck(BatchFileBaseCheck):
         def _process_line_comments(self, lines, start_index, texts, log_func):
             processed_lines = []
             i = start_index
-            prefix = '//' # Hardcoded as per comments.py logic
             
             while i < len(lines):
                 line = lines[i]
@@ -114,7 +113,7 @@ class FileCopyrightCheck(BatchFileBaseCheck):
                     i += 1
                     continue
                     
-                if not stripped.startswith(prefix):
+                if not any(stripped.startswith(prefix) for prefix in LINE_PREFIXES):
                     break
                 
                 if self._contains_text(stripped, texts):
@@ -131,15 +130,19 @@ class FileCopyrightCheck(BatchFileBaseCheck):
         def _process_block_comments(self, lines, start_index, texts, log_func):
             processed_lines = []
             i = start_index
-            block_start = BLOCK_START
-            block_end = BLOCK_END
             
             while i < len(lines):
                 line = lines[i]
                 stripped = line.strip()
                 
-                if block_end in line:
-                    new_line = self._handle_block_end_line(line, texts, block_start, block_end, log_func)
+                block_end = None
+                for end in BLOCK_ENDS:
+                    if end in line:
+                        block_end = end
+                        break
+                
+                if block_end:
+                    new_line = self._handle_block_end_line(line, texts, block_end, log_func)
                     processed_lines.append(new_line)
                     i += 1
                     break
@@ -156,7 +159,7 @@ class FileCopyrightCheck(BatchFileBaseCheck):
                 
             return processed_lines, i
 
-        def _handle_block_end_line(self, line, texts, block_start, block_end, log_func):
+        def _handle_block_end_line(self, line, texts, block_end, log_func):
             pre, sep, post = line.partition(block_end)
             lower_pre = pre.lower()
             
@@ -169,13 +172,20 @@ class FileCopyrightCheck(BatchFileBaseCheck):
             if found_text:
                 if log_func:
                     log_func(f"Removing line content: {line.strip()}")
-                return self._reconstruct_block_end_line(pre, sep, post, block_start)
+                return self._reconstruct_block_end_line(pre, sep, post)
             
             return line
 
-        def _reconstruct_block_end_line(self, pre, sep, post, block_start):
+        def _reconstruct_block_end_line(self, pre, sep, post):
             new_line_content = ""
-            if block_start in pre:
+            
+            block_start = None
+            for start in BLOCK_STARTS:
+                if start in pre:
+                    block_start = start
+                    break
+            
+            if block_start:
                  start_idx = pre.find(block_start)
                  new_line_content += pre[:start_idx + len(block_start)] + " "
             else:

--- a/beman_tidy/lib/utils/comments.py
+++ b/beman_tidy/lib/utils/comments.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+from enum import Enum, auto
+
+class CommentType(Enum):
+    LINE = auto()
+    BLOCK = auto()
+
+# Currently only supports C/C++ comments
+LINE_PREFIX = '//'
+BLOCK_START = '/*'
+BLOCK_END = '*/'
+
+def determine_comment_style(lines, line_index):
+    """
+    Determines the comment style at the given line index.
+    Returns CommentType or None.
+    """
+    if line_index < 0 or line_index >= len(lines):
+        return None
+        
+    line = lines[line_index].strip()
+    
+    # Check for line comments
+    if line.startswith(LINE_PREFIX):
+        return CommentType.LINE
+        
+    # Check for block comment start
+    if line.startswith(BLOCK_START):
+        return CommentType.BLOCK
+        
+    # Check if inside block comment (look backwards)
+    for i in range(line_index - 1, -1, -1):
+        prev_line = lines[i].strip()
+        if BLOCK_END in prev_line:
+            # Found an end marker before a start marker, so we are not inside a block
+            return None
+            
+        if prev_line.startswith(BLOCK_START):
+             return CommentType.BLOCK
+             
+    return None

--- a/beman_tidy/lib/utils/comments.py
+++ b/beman_tidy/lib/utils/comments.py
@@ -29,15 +29,19 @@ def determine_comment_style(lines, line_index):
     if any(line.startswith(start) for start in BLOCK_STARTS):
         return CommentType.BLOCK
         
-    # Check if inside block comment (look backwards)
+    # Check if inside block comment
     for i in range(line_index - 1, -1, -1):
         prev_line = lines[i].strip()
-        
-        # If start marker is found before end marker, we are not inside a block
-        if any(end in prev_line for end in BLOCK_ENDS):
+
+        has_start = any(prev_line.startswith(start) for start in BLOCK_STARTS)
+        has_end = any(end in prev_line for end in BLOCK_ENDS)
+
+        if has_start and has_end:
+            continue
+        elif has_end:
             return None
-            
-        if any(prev_line.startswith(start) for start in BLOCK_STARTS):
+        elif has_start:
+            # We are inside the block
             return CommentType.BLOCK
              
     return None

--- a/beman_tidy/lib/utils/comments.py
+++ b/beman_tidy/lib/utils/comments.py
@@ -6,10 +6,10 @@ class CommentType(Enum):
     LINE = auto()
     BLOCK = auto()
 
-# Currently only supports C/C++ comments
-LINE_PREFIX = '//'
-BLOCK_START = '/*'
-BLOCK_END = '*/'
+# Supports multiple comment styles
+LINE_PREFIXES = ['//']
+BLOCK_STARTS = ['/*']
+BLOCK_ENDS = ['*/']
 
 def determine_comment_style(lines, line_index):
     """
@@ -22,21 +22,22 @@ def determine_comment_style(lines, line_index):
     line = lines[line_index].strip()
     
     # Check for line comments
-    if line.startswith(LINE_PREFIX):
+    if any(line.startswith(prefix) for prefix in LINE_PREFIXES):
         return CommentType.LINE
         
     # Check for block comment start
-    if line.startswith(BLOCK_START):
+    if any(line.startswith(start) for start in BLOCK_STARTS):
         return CommentType.BLOCK
         
     # Check if inside block comment (look backwards)
     for i in range(line_index - 1, -1, -1):
         prev_line = lines[i].strip()
-        if BLOCK_END in prev_line:
-            # Found an end marker before a start marker, so we are not inside a block
+        
+        # If start marker is found before end marker, we are not inside a block
+        if any(end in prev_line for end in BLOCK_ENDS):
             return None
             
-        if prev_line.startswith(BLOCK_START):
+        if any(prev_line.startswith(start) for start in BLOCK_STARTS):
             return CommentType.BLOCK
              
     return None
@@ -60,8 +61,10 @@ def iterate_comment_lines(lines, start_index, comment_type):
                 yield i, line
                 i += 1
                 continue
-            if not stripped.startswith(LINE_PREFIX):
+            
+            if not any(stripped.startswith(prefix) for prefix in LINE_PREFIXES):
                 break
+            
             yield i, line
             i += 1
 
@@ -69,7 +72,7 @@ def iterate_comment_lines(lines, start_index, comment_type):
         while i < len(lines):
             line = lines[i]
             yield i, line
-            if BLOCK_END in line:
+            if any(end in line for end in BLOCK_ENDS):
                 break
             i += 1
 
@@ -80,8 +83,11 @@ def find_in_comment(lines, start_index, comment_type, texts, ignore_case=False):
     Returns (line_index, found_text) or (None, None).
     """
     for i, line in iterate_comment_lines(lines, start_index, comment_type):
-        if comment_type == CommentType.BLOCK and BLOCK_END in line:
-            line = line.split(BLOCK_END)[0]
+        if comment_type == CommentType.BLOCK:
+            for end in BLOCK_ENDS:
+                if end in line:
+                    line = line.split(end)[0]
+                    break
 
         found_text = find_in_line(line, texts, ignore_case)
         if found_text:

--- a/beman_tidy/lib/utils/comments.py
+++ b/beman_tidy/lib/utils/comments.py
@@ -37,6 +37,67 @@ def determine_comment_style(lines, line_index):
             return None
             
         if prev_line.startswith(BLOCK_START):
-             return CommentType.BLOCK
+            return CommentType.BLOCK
              
+    return None
+
+
+def iterate_comment_lines(lines, start_index, comment_type):
+    """
+    Iterates over the lines of a comment block starting at start_index.
+    Yields (line_index, line_content).
+    Stops when the comment block ends.
+    """
+    if start_index < 0 or start_index >= len(lines) or comment_type is None:
+        return
+
+    i = start_index
+    if comment_type == CommentType.LINE:
+        while i < len(lines):
+            line = lines[i]
+            stripped = line.strip()
+            if not stripped:
+                yield i, line
+                i += 1
+                continue
+            if not stripped.startswith(LINE_PREFIX):
+                break
+            yield i, line
+            i += 1
+
+    elif comment_type == CommentType.BLOCK:
+        while i < len(lines):
+            line = lines[i]
+            yield i, line
+            if BLOCK_END in line:
+                break
+            i += 1
+
+
+def find_in_comment(lines, start_index, comment_type, texts, ignore_case=False):
+    """
+    Searches for any of the text in texts list within the comment block.
+    Returns (line_index, found_text) or (None, None).
+    """
+    for i, line in iterate_comment_lines(lines, start_index, comment_type):
+        if comment_type == CommentType.BLOCK and BLOCK_END in line:
+            line = line.split(BLOCK_END)[0]
+
+        found_text = find_in_line(line, texts, ignore_case)
+        if found_text:
+            return i, found_text
+    return None, None
+
+
+def find_in_line(line, texts, ignore_case=False):
+    """
+    Checks if line contains any of the texts.
+    Optionally ignores case.
+    Returns the found text or None.
+    """
+    if ignore_case:
+        line = line.lower()
+    for text in texts:
+        if (text.lower() if ignore_case else text) in line:
+            return text
     return None

--- a/beman_tidy/lib/utils/comments.py
+++ b/beman_tidy/lib/utils/comments.py
@@ -11,7 +11,7 @@ LINE_PREFIXES = ['//']
 BLOCK_STARTS = ['/*']
 BLOCK_ENDS = ['*/']
 
-def determine_comment_style(lines, line_index):
+def determine_comment_type(lines, line_index):
     """
     Determines the comment style at the given line index.
     Returns CommentType or None.

--- a/beman_tidy/lib/utils/file.py
+++ b/beman_tidy/lib/utils/file.py
@@ -57,10 +57,10 @@ def get_cpp_files(repo_path):
     return get_matched_paths(repo_path, get_cpp_extensions())
 
 
-def get_spdx_type(lines):
+def get_spdx_info(lines):
     """
-    Helper to find the SPDX line index and the comment type.
-    Returns (spdx_index, comment_type).
+    Helper to find the SPDX line index and the comment info.
+    Returns (spdx_index, comment_info).
 
     If not found or invalid, returns (-1, None).
     """
@@ -72,5 +72,5 @@ def get_spdx_type(lines):
     if spdx_index == -1:
         return -1, None
 
-    comment_type = determine_comment_type(lines, spdx_index)
-    return spdx_index, comment_type
+    comment_info = determine_comment_type(lines, spdx_index)
+    return spdx_index, comment_info

--- a/beman_tidy/lib/utils/file.py
+++ b/beman_tidy/lib/utils/file.py
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from pathlib import Path
-from .comments import determine_comment_style
+from .comments import determine_comment_type
 
 
 def get_repo_ignorable_subdirectories():
@@ -57,9 +57,9 @@ def get_cpp_files(repo_path):
     return get_matched_paths(repo_path, get_cpp_extensions())
 
 
-def get_spdx_info(lines):
+def get_spdx_type(lines):
     """
-    Helper to find the SPDX line index and the comment style.
+    Helper to find the SPDX line index and the comment type.
     Returns (spdx_index, comment_type).
 
     If not found or invalid, returns (-1, None).
@@ -72,5 +72,5 @@ def get_spdx_info(lines):
     if spdx_index == -1:
         return -1, None
 
-    comment_type = determine_comment_style(lines, spdx_index)
+    comment_type = determine_comment_type(lines, spdx_index)
     return spdx_index, comment_type

--- a/beman_tidy/lib/utils/file.py
+++ b/beman_tidy/lib/utils/file.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from pathlib import Path
+from .comments import determine_comment_style
 
 
 def get_repo_ignorable_subdirectories():
@@ -58,23 +59,18 @@ def get_cpp_files(repo_path):
 
 def get_spdx_info(lines):
     """
-    Helper to find the SPDX line index and the comment prefix.
-    Returns (spdx_index, comment_prefix).
+    Helper to find the SPDX line index and the comment style.
+    Returns (spdx_index, comment_type).
+
     If not found or invalid, returns (-1, None).
     """
     spdx_index = next(
         (i for i, line in enumerate(lines) if "SPDX-License-Identifier:" in line),
         -1
     )
-    
+
     if spdx_index == -1:
         return -1, None
 
-    spdx_line = lines[spdx_index].strip()
-    comment_prefix = None
-    if spdx_line.startswith("//"):
-        comment_prefix = "//"
-    elif spdx_line.startswith("#"):
-        comment_prefix = "#"
-        
-    return spdx_index, comment_prefix
+    comment_type = determine_comment_style(lines, spdx_index)
+    return spdx_index, comment_type

--- a/tests/lib/checks/beman_standard/file/data/invalid/invalid.cpp
+++ b/tests/lib/checks/beman_standard/file/data/invalid/invalid.cpp
@@ -1,3 +1,3 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-// Copyright 2024 Beman & Durlea Andrei
+// Copyright 2026 Beman & Durlea Andrei

--- a/tests/lib/checks/beman_standard/file/data/invalid/invalid.hpp
+++ b/tests/lib/checks/beman_standard/file/data/invalid/invalid.hpp
@@ -1,2 +1,2 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
-// Copyright (c) 2024 Beman & Durlea Andrei
+// Copyright (c) 2026 Beman & Durlea Andrei

--- a/tests/lib/checks/beman_standard/file/data/invalid_block/invalid.cpp
+++ b/tests/lib/checks/beman_standard/file/data/invalid_block/invalid.cpp
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
+/* Copyright 2026 Beman & Durlea Andrei */

--- a/tests/lib/checks/beman_standard/file/data/invalid_block/invalid.hpp
+++ b/tests/lib/checks/beman_standard/file/data/invalid_block/invalid.hpp
@@ -1,0 +1,3 @@
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ * Copyright 2026 Beman Project
+ */

--- a/tests/lib/checks/beman_standard/file/data/valid_block/valid.cpp
+++ b/tests/lib/checks/beman_standard/file/data/valid_block/valid.cpp
@@ -1,0 +1,8 @@
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
+#include <iostream>
+
+/* Copyright is not in header */
+void foo() {
+    /* Copyright notice here is fine? */
+}

--- a/tests/lib/checks/beman_standard/file/data/valid_block/valid.hpp
+++ b/tests/lib/checks/beman_standard/file/data/valid_block/valid.hpp
@@ -1,0 +1,9 @@
+/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */
+
+#ifndef VALID_HPP
+#define VALID_HPP
+
+/* Copyright is not in header */
+void bar();
+
+#endif

--- a/tests/lib/checks/beman_standard/file/test_file.py
+++ b/tests/lib/checks/beman_standard/file/test_file.py
@@ -9,16 +9,30 @@ from beman_tidy.lib.checks.beman_standard.file import FileCopyrightCheck
 test_data_prefix = Path("tests/lib/checks/beman_standard/file/data")
 valid_prefix = test_data_prefix / "valid"
 invalid_prefix = test_data_prefix / "invalid"
+valid_block_prefix = test_data_prefix / "valid_block"
+invalid_block_prefix = test_data_prefix / "invalid_block"
 
 def test__file_copyright__valid(repo_info, beman_standard_check_config):
     repo_info["top_level"] = valid_prefix
-    
+
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
     assert check.check() is True
 
 def test__file_copyright__invalid(repo_info, beman_standard_check_config):
     repo_info["top_level"] = invalid_prefix
-    
+
+    check = FileCopyrightCheck(repo_info, beman_standard_check_config)
+    assert check.check() is False
+
+def test__file_copyright__valid_block_comments(repo_info, beman_standard_check_config):
+    repo_info["top_level"] = valid_block_prefix
+
+    check = FileCopyrightCheck(repo_info, beman_standard_check_config)
+    assert check.check() is True
+
+def test__file_copyright__invalid_block_comments(repo_info, beman_standard_check_config):
+    repo_info["top_level"] = invalid_block_prefix
+
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
     assert check.check() is False
 
@@ -26,26 +40,56 @@ def test__file_copyright__fix_inplace(repo_info, beman_standard_check_config, tm
     for item in invalid_prefix.iterdir():
         if item.is_file():
             shutil.copy(item, tmp_path / item.name)
-    
+
     repo_info["top_level"] = tmp_path
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
-    
+
     assert check.check() is False
-    
+
     assert check.fix() is True
-    
+
     assert check.check() is True
-    
+
     for item in invalid_prefix.iterdir():
         if not item.is_file():
             continue
-            
+
         fixed_file = tmp_path / item.name
         content = fixed_file.read_text()
         lines = content.splitlines()
-        
+
         for line in lines:
             if "SPDX-License-Identifier:" in line:
                 continue
             if line.strip().startswith("//"):
                  assert "Copyright" not in line, f"Copyright still present in {fixed_file.name}: {line}"
+
+def test__file_copyright__fix_inplace_block_comments(repo_info, beman_standard_check_config, tmp_path):
+    for item in invalid_block_prefix.iterdir():
+        if item.is_file():
+            shutil.copy(item, tmp_path / item.name)
+
+    repo_info["top_level"] = tmp_path
+    check = FileCopyrightCheck(repo_info, beman_standard_check_config)
+
+    assert check.check() is False
+
+    assert check.fix() is True
+
+    assert check.check() is True
+
+    for item in invalid_block_prefix.iterdir():
+        if not item.is_file():
+            continue
+
+        fixed_file = tmp_path / item.name
+        content = fixed_file.read_text()
+        lines = content.splitlines()
+
+        for line in lines:
+            if "SPDX-License-Identifier:" in line:
+                continue
+            # Check both single-line block comments and multi-line block comments
+            stripped = line.strip()
+            if stripped.startswith("/*") or stripped.startswith("*"):
+                assert "Copyright" not in line, f"Copyright still present in {fixed_file.name}: {line}"

--- a/tests/lib/checks/beman_standard/file/test_file.py
+++ b/tests/lib/checks/beman_standard/file/test_file.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 from beman_tidy.lib.checks.beman_standard.file import FileCopyrightCheck
 
-# workaround to test for both normal and block comments
+# Workaround to test for both normal and block comments.
 test_data_prefix = Path("tests/lib/checks/beman_standard/file/data")
 valid_prefix = test_data_prefix / "valid"
 invalid_prefix = test_data_prefix / "invalid"
@@ -33,13 +33,13 @@ def test__file_copyright__invalid(repo_info, beman_standard_check_config):
 
 def test__file_copyright__fix_inplace(repo_info, beman_standard_check_config, tmp_path):
     # Test with invalid_prefix
-    dir1 = tmp_path / "invalid"
-    dir1.mkdir()
+    invalid_dir = tmp_path / "invalid"
+    invalid_dir.mkdir()
     for item in invalid_prefix.iterdir():
         if item.is_file():
-            shutil.copy(item, dir1 / item.name)
+            shutil.copy(item, invalid_dir / item.name)
 
-    repo_info["top_level"] = dir1
+    repo_info["top_level"] = invalid_dir
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
 
     assert check.check() is False
@@ -50,7 +50,7 @@ def test__file_copyright__fix_inplace(repo_info, beman_standard_check_config, tm
         if not item.is_file():
             continue
 
-        fixed_file = dir1 / item.name
+        fixed_file = invalid_dir / item.name
         content = fixed_file.read_text()
         lines = content.splitlines()
 
@@ -61,13 +61,13 @@ def test__file_copyright__fix_inplace(repo_info, beman_standard_check_config, tm
                  assert "Copyright" not in line, f"Copyright still present in {fixed_file.name}: {line}"
 
     # Test with invalid_block_prefix
-    dir2 = tmp_path / "invalid_block"
-    dir2.mkdir()
+    invalid_block_dir = tmp_path / "invalid_block"
+    invalid_block_dir.mkdir()
     for item in invalid_block_prefix.iterdir():
         if item.is_file():
-            shutil.copy(item, dir2 / item.name)
+            shutil.copy(item, invalid_block_dir / item.name)
 
-    repo_info["top_level"] = dir2
+    repo_info["top_level"] = invalid_block_dir
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
 
     assert check.check() is False
@@ -78,7 +78,7 @@ def test__file_copyright__fix_inplace(repo_info, beman_standard_check_config, tm
         if not item.is_file():
             continue
 
-        fixed_file = dir2 / item.name
+        fixed_file = invalid_block_dir / item.name
         content = fixed_file.read_text()
         lines = content.splitlines()
 

--- a/tests/lib/checks/beman_standard/file/test_file.py
+++ b/tests/lib/checks/beman_standard/file/test_file.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from beman_tidy.lib.checks.beman_standard.file import FileCopyrightCheck
 
+# workaround to test for both normal and block comments
 test_data_prefix = Path("tests/lib/checks/beman_standard/file/data")
 valid_prefix = test_data_prefix / "valid"
 invalid_prefix = test_data_prefix / "invalid"
@@ -14,47 +15,42 @@ invalid_block_prefix = test_data_prefix / "invalid_block"
 
 def test__file_copyright__valid(repo_info, beman_standard_check_config):
     repo_info["top_level"] = valid_prefix
+    check = FileCopyrightCheck(repo_info, beman_standard_check_config)
+    assert check.check() is True
 
+    repo_info["top_level"] = valid_block_prefix
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
     assert check.check() is True
 
 def test__file_copyright__invalid(repo_info, beman_standard_check_config):
     repo_info["top_level"] = invalid_prefix
-
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
     assert check.check() is False
 
-def test__file_copyright__valid_block_comments(repo_info, beman_standard_check_config):
-    repo_info["top_level"] = valid_block_prefix
-
-    check = FileCopyrightCheck(repo_info, beman_standard_check_config)
-    assert check.check() is True
-
-def test__file_copyright__invalid_block_comments(repo_info, beman_standard_check_config):
     repo_info["top_level"] = invalid_block_prefix
-
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
     assert check.check() is False
 
 def test__file_copyright__fix_inplace(repo_info, beman_standard_check_config, tmp_path):
+    # Test with invalid_prefix
+    dir1 = tmp_path / "invalid"
+    dir1.mkdir()
     for item in invalid_prefix.iterdir():
         if item.is_file():
-            shutil.copy(item, tmp_path / item.name)
+            shutil.copy(item, dir1 / item.name)
 
-    repo_info["top_level"] = tmp_path
+    repo_info["top_level"] = dir1
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
 
     assert check.check() is False
-
     assert check.fix() is True
-
     assert check.check() is True
 
     for item in invalid_prefix.iterdir():
         if not item.is_file():
             continue
 
-        fixed_file = tmp_path / item.name
+        fixed_file = dir1 / item.name
         content = fixed_file.read_text()
         lines = content.splitlines()
 
@@ -64,25 +60,25 @@ def test__file_copyright__fix_inplace(repo_info, beman_standard_check_config, tm
             if line.strip().startswith("//"):
                  assert "Copyright" not in line, f"Copyright still present in {fixed_file.name}: {line}"
 
-def test__file_copyright__fix_inplace_block_comments(repo_info, beman_standard_check_config, tmp_path):
+    # Test with invalid_block_prefix
+    dir2 = tmp_path / "invalid_block"
+    dir2.mkdir()
     for item in invalid_block_prefix.iterdir():
         if item.is_file():
-            shutil.copy(item, tmp_path / item.name)
+            shutil.copy(item, dir2 / item.name)
 
-    repo_info["top_level"] = tmp_path
+    repo_info["top_level"] = dir2
     check = FileCopyrightCheck(repo_info, beman_standard_check_config)
 
     assert check.check() is False
-
     assert check.fix() is True
-
     assert check.check() is True
 
     for item in invalid_block_prefix.iterdir():
         if not item.is_file():
             continue
 
-        fixed_file = tmp_path / item.name
+        fixed_file = dir2 / item.name
         content = fixed_file.read_text()
         lines = content.splitlines()
 

--- a/tests/lib/utils/comments.py
+++ b/tests/lib/utils/comments.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
-import pytest
-
 from beman_tidy.lib.utils.comments import (
     BLOCK_ENDS,
     BLOCK_STARTS,

--- a/tests/lib/utils/comments.py
+++ b/tests/lib/utils/comments.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+
+from beman_tidy.lib.utils.comments import (
+    BLOCK_ENDS,
+    BLOCK_STARTS,
+    LINE_PREFIXES,
+    CommentType,
+    determine_comment_style,
+    find_in_comment,
+    find_in_line,
+    iterate_comment_lines,
+)
+
+
+def test__comments__determine_comment_style__out_of_bounds():
+    assert determine_comment_style([], 0) is None
+    assert determine_comment_style(["// hi"], -1) is None
+    assert determine_comment_style(["// hi"], 1) is None
+
+
+def test__comments__determine_comment_style__line_comment():
+    lines = [
+        "int x = 0;\n",
+        "// comment\n",
+    ]
+    assert determine_comment_style(lines, 1) == CommentType.LINE
+
+
+def test__comments__determine_comment_style__block_comment_start():
+    lines = [
+        "/* comment start\n",
+        " * middle\n",
+        " */\n",
+    ]
+    assert determine_comment_style(lines, 0) == CommentType.BLOCK
+
+
+def test__comments__determine_comment_style__inside_block_comment():
+    lines = [
+        "/* comment start\n",
+        " * middle\n",
+        " */\n",
+        "int x = 0;\n",
+    ]
+    assert determine_comment_style(lines, 1) == CommentType.BLOCK
+
+
+def test__comments__determine_comment_style__after_block_comment_is_none():
+    lines = [
+        "/* comment start\n",
+        " */\n",
+        "int x = 0;\n",
+    ]
+    assert determine_comment_style(lines, 2) is None
+
+
+def test__comments__iterate_comment_lines__line_comment_block_with_blank_lines():
+    lines = [
+        "// a\n",
+        "\n",
+        "// b\n",
+        "int x = 0;\n",
+        "// c\n",  # should not be reached
+    ]
+    out = list(iterate_comment_lines(lines, 0, CommentType.LINE))
+    assert out == [
+        (0, "// a\n"),
+        (1, "\n"),
+        (2, "// b\n"),
+    ]
+
+
+def test__comments__iterate_comment_lines__block_comment_until_end_marker():
+    lines = [
+        "/* a\n",
+        " * b\n",
+        " */ trailing\n",
+        "int x = 0;\n",
+    ]
+    out = list(iterate_comment_lines(lines, 0, CommentType.BLOCK))
+    assert out == [
+        (0, "/* a\n"),
+        (1, " * b\n"),
+        (2, " */ trailing\n"),
+    ]
+
+
+def test__comments__iterate_comment_lines__invalid_start_index_or_type_yields_nothing():
+    lines = ["// a\n"]
+    assert list(iterate_comment_lines(lines, -1, CommentType.LINE)) == []
+    assert list(iterate_comment_lines(lines, 0, None)) == []
+
+
+def test__comments__find_in_line__case_sensitive_and_insensitive():
+    assert find_in_line("Hello World", ["world"]) is None
+    assert find_in_line("Hello World", ["world"], ignore_case=True) == "world"
+    assert find_in_line("abc", ["x", "b"]) == "b"
+
+
+def test__comments__find_in_comment__line_comment_finds_text():
+    lines = [
+        "// SPDX-License-Identifier: X\n",
+        "// Copyright 2024 Somebody\n",
+        "int x = 0;\n",
+    ]
+    line_idx, found = find_in_comment(lines, 1, CommentType.LINE, ["copyright"], ignore_case=True)
+    assert line_idx == 1
+    assert found == "copyright"
+
+
+def test__comments__find_in_comment__block_comment_finds_text_before_end():
+    lines = [
+        "/* SPDX-License-Identifier: X\n",
+        " * Copyright 2024 Somebody\n",
+        " */\n",
+    ]
+    line_idx, found = find_in_comment(lines, 0, CommentType.BLOCK, ["copyright"], ignore_case=True)
+    assert line_idx == 1
+    assert found == "copyright"
+
+
+def test__comments__find_in_comment__block_comment_ignores_text_after_block_end_on_same_line():
+    # The implementation truncates the line at '*/' before searching.
+    lines = [
+        "/* header */ copyright SHOULD_NOT_MATCH\n",
+        "int x = 0;\n",
+    ]
+    line_idx, found = find_in_comment(lines, 0, CommentType.BLOCK, ["copyright"], ignore_case=True)
+    assert (line_idx, found) == (None, None)
+
+
+def test__comments__comment_markers_are_non_empty():
+    assert LINE_PREFIXES
+    assert BLOCK_STARTS
+    assert BLOCK_ENDS

--- a/tests/lib/utils/comments.py
+++ b/tests/lib/utils/comments.py
@@ -6,7 +6,7 @@ from beman_tidy.lib.utils.comments import (
     BLOCK_STARTS,
     LINE_PREFIXES,
     CommentType,
-    determine_comment_style,
+    determine_comment_type,
     find_in_comment,
     find_in_line,
     iterate_comment_lines,
@@ -14,9 +14,9 @@ from beman_tidy.lib.utils.comments import (
 
 
 def test__comments__determine_comment_style__out_of_bounds():
-    assert determine_comment_style([], 0) is None
-    assert determine_comment_style(["// hi"], -1) is None
-    assert determine_comment_style(["// hi"], 1) is None
+    assert determine_comment_type([], 0) is None
+    assert determine_comment_type(["// hi"], -1) is None
+    assert determine_comment_type(["// hi"], 1) is None
 
 
 def test__comments__determine_comment_style__line_comment():
@@ -24,7 +24,7 @@ def test__comments__determine_comment_style__line_comment():
         "int x = 0;\n",
         "// comment\n",
     ]
-    assert determine_comment_style(lines, 1) == CommentType.LINE
+    assert determine_comment_type(lines, 1) == CommentType.LINE
 
 
 def test__comments__determine_comment_style__block_comment_start():
@@ -33,7 +33,7 @@ def test__comments__determine_comment_style__block_comment_start():
         " * middle\n",
         " */\n",
     ]
-    assert determine_comment_style(lines, 0) == CommentType.BLOCK
+    assert determine_comment_type(lines, 0) == CommentType.BLOCK
 
 
 def test__comments__determine_comment_style__inside_block_comment():
@@ -43,7 +43,7 @@ def test__comments__determine_comment_style__inside_block_comment():
         " */\n",
         "int x = 0;\n",
     ]
-    assert determine_comment_style(lines, 1) == CommentType.BLOCK
+    assert determine_comment_type(lines, 1) == CommentType.BLOCK
 
 
 def test__comments__determine_comment_style__after_block_comment_is_none():
@@ -52,7 +52,7 @@ def test__comments__determine_comment_style__after_block_comment_is_none():
         " */\n",
         "int x = 0;\n",
     ]
-    assert determine_comment_style(lines, 2) is None
+    assert determine_comment_type(lines, 2) is None
 
 
 def test__comments__determine_comment_style__single_line_block_comment():
@@ -60,7 +60,7 @@ def test__comments__determine_comment_style__single_line_block_comment():
         "/* single-line block comment */\n",
         "int x = 0;\n",
     ]
-    assert determine_comment_style(lines, 0) == CommentType.BLOCK
+    assert determine_comment_type(lines, 0) == CommentType.BLOCK
 
 
 def test__comments__determine_comment_style__after_single_line_block_comment():
@@ -68,7 +68,7 @@ def test__comments__determine_comment_style__after_single_line_block_comment():
         "/* single-line block comment */\n",
         "int x = 0;\n",
     ]
-    assert determine_comment_style(lines, 1) is None
+    assert determine_comment_type(lines, 1) is None
 
 
 def test__comments__determine_comment_style__not_inside_single_line_block_comment():
@@ -78,9 +78,9 @@ def test__comments__determine_comment_style__not_inside_single_line_block_commen
         "/* Copyright notice */\n",
     ]
     # Line 2 (the blank line) should NOT be considered inside a block comment
-    assert determine_comment_style(lines, 1) is None
+    assert determine_comment_type(lines, 1) is None
     # Line 2 (the Copyright line) is its own single-line block comment
-    assert determine_comment_style(lines, 2) == CommentType.BLOCK
+    assert determine_comment_type(lines, 2) == CommentType.BLOCK
 
 
 def test__comments__iterate_comment_lines__line_comment_block_with_blank_lines():

--- a/tests/lib/utils/comments.py
+++ b/tests/lib/utils/comments.py
@@ -57,6 +57,34 @@ def test__comments__determine_comment_style__after_block_comment_is_none():
     assert determine_comment_style(lines, 2) is None
 
 
+def test__comments__determine_comment_style__single_line_block_comment():
+    lines = [
+        "/* single-line block comment */\n",
+        "int x = 0;\n",
+    ]
+    assert determine_comment_style(lines, 0) == CommentType.BLOCK
+
+
+def test__comments__determine_comment_style__after_single_line_block_comment():
+    lines = [
+        "/* single-line block comment */\n",
+        "int x = 0;\n",
+    ]
+    assert determine_comment_style(lines, 1) is None
+
+
+def test__comments__determine_comment_style__not_inside_single_line_block_comment():
+    lines = [
+        "/* SPDX-License-Identifier: Apache-2.0 */\n",
+        "\n",
+        "/* Copyright notice */\n",
+    ]
+    # Line 2 (the blank line) should NOT be considered inside a block comment
+    assert determine_comment_style(lines, 1) is None
+    # Line 2 (the Copyright line) is its own single-line block comment
+    assert determine_comment_style(lines, 2) == CommentType.BLOCK
+
+
 def test__comments__iterate_comment_lines__line_comment_block_with_blank_lines():
     lines = [
         "// a\n",
@@ -94,6 +122,17 @@ def test__comments__iterate_comment_lines__invalid_start_index_or_type_yields_no
     assert list(iterate_comment_lines(lines, 0, None)) == []
 
 
+def test__comments__iterate_comment_lines__single_line_block_comment():
+    lines = [
+        "/* single-line block */\n",
+        "int x = 0;\n",
+    ]
+    out = list(iterate_comment_lines(lines, 0, CommentType.BLOCK))
+    assert out == [
+        (0, "/* single-line block */\n"),
+    ]
+
+
 def test__comments__find_in_line__case_sensitive_and_insensitive():
     assert find_in_line("Hello World", ["world"]) is None
     assert find_in_line("Hello World", ["world"], ignore_case=True) == "world"
@@ -103,7 +142,7 @@ def test__comments__find_in_line__case_sensitive_and_insensitive():
 def test__comments__find_in_comment__line_comment_finds_text():
     lines = [
         "// SPDX-License-Identifier: X\n",
-        "// Copyright 2024 Somebody\n",
+        "// Copyright 2026 Durlea Andrei\n",
         "int x = 0;\n",
     ]
     line_idx, found = find_in_comment(lines, 1, CommentType.LINE, ["copyright"], ignore_case=True)
@@ -114,7 +153,7 @@ def test__comments__find_in_comment__line_comment_finds_text():
 def test__comments__find_in_comment__block_comment_finds_text_before_end():
     lines = [
         "/* SPDX-License-Identifier: X\n",
-        " * Copyright 2024 Somebody\n",
+        " * Copyright 2026 Beman\n",
         " */\n",
     ]
     line_idx, found = find_in_comment(lines, 0, CommentType.BLOCK, ["copyright"], ignore_case=True)
@@ -129,6 +168,30 @@ def test__comments__find_in_comment__block_comment_ignores_text_after_block_end_
         "int x = 0;\n",
     ]
     line_idx, found = find_in_comment(lines, 0, CommentType.BLOCK, ["copyright"], ignore_case=True)
+    assert (line_idx, found) == (None, None)
+
+
+def test__comments__find_in_comment__single_line_block_comment_finds_text():
+    lines = [
+        "/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */\n",
+        "\n",
+        "/* Copyright 2026 Beman */\n",
+    ]
+    # Should find copyright in the separate single-line block comment on line 2
+    line_idx, found = find_in_comment(lines, 2, CommentType.BLOCK, ["copyright"], ignore_case=True)
+    assert line_idx == 2
+    assert found == "copyright"
+
+
+def test__comments__find_in_comment__does_not_find_in_next_single_line_block():
+    lines = [
+        "/* SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception */\n",
+        "\n",
+        "/* Copyright 2026 Beman */\n",
+    ]
+    # Starting search from line 1 (after SPDX single-line comment) should NOT find copyright
+    # because we're not inside a block comment at line 1
+    line_idx, found = find_in_comment(lines, 1, None, ["copyright"], ignore_case=True)
     assert (line_idx, found) == (None, None)
 
 

--- a/tests/lib/utils/conftest.py
+++ b/tests/lib/utils/conftest.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import pytest
+
+from tests.utils.conftest import mock_repo_info, mock_beman_standard_check_config  # noqa: F401
+
+
+@pytest.fixture(autouse=True)
+def repo_info(mock_repo_info):  # noqa: F811
+    return mock_repo_info
+
+
+@pytest.fixture
+def beman_standard_check_config(mock_beman_standard_check_config):  # noqa: F811
+    return mock_beman_standard_check_config


### PR DESCRIPTION
#226
Initial implementation:
- Added utils/comments.py containing utiluity functions for dealing with comments (block or line)
- Modified file.copyright `check()` and `fix()` to accomodate both block and line comments
- comments.py [supports the addition of new start/end comment identifiers from other languages in the future](https://github.com/bemanproject/beman-tidy/pull/229/changes#diff-1017129a26ce102d000aadc53346a0b25baae316f05887115fabb0fb6e364969R9)