### PR TITLE
[CI] Update `astral-sh/setup-uv` version in GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8
         with:
           enable-cache: true
 


### PR DESCRIPTION
This updates the version of the `astral-sh/setup-uv@v6` used in GitHub Actions to address the Node 20 deprecation warning.