### PR TITLE
feat(cli): add --version flag (#269)

### DIFF
--- a/beman_tidy/cli.py
+++ b/beman_tidy/cli.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import argparse
+from importlib.metadata import version as _pkg_version
 import sys
 
 from beman_tidy.lib.utils.git import get_repo_info, load_beman_standard_config
@@ -14,6 +15,11 @@ def parse_args():
     """
 
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"beman-tidy {_pkg_version('beman-tidy')}",
+    )
     parser.add_argument("repo_path", help="path to the repository to check", type=str)
     parser.add_argument(
         "--fix-inplace",
@@ -37,7 +43,10 @@ def parse_args():
         "--checks", help="array of checks to run", type=str, default=None
     )
     parser.add_argument(
-        "--config", help="path to the configuration file (default: .beman-tidy.yaml in repo root)", type=str, default=None
+        "--config",
+        help="path to the configuration file (default: .beman-tidy.yaml in repo root)",
+        type=str,
+        default=None,
     )
     args = parser.parse_args()
 


### PR DESCRIPTION
Closes #269.

Adds a `--version` flag to the `beman-tidy` CLI so users can check the installed version without running `pipx list | grep beman-tidy`.

## Before

\`\`\`
\$ beman-tidy --version
usage: beman-tidy [-h] [--fix-inplace | --no-fix-inplace] ...
beman-tidy: error: the following arguments are required: repo_path
\`\`\`

## After

\`\`\`
\$ beman-tidy --version
beman-tidy 0.4.0
\`\`\`

## Implementation notes

- Uses argparse's built-in \`action="version"\`, which short-circuits before argparse validates the required \`repo_path\` positional.
- Reads the version via \`importlib.metadata.version("beman-tidy")\` rather than hardcoding a string — stays in sync with \`pyproject.toml\` automatically.
- \`importlib.metadata\` is stdlib; no new dependencies (project already requires Python 3.12+).

Ran \`uv run pytest tests/\` (69 passed) and \`uv run ruff check beman_tidy/cli.py\` (passes). Formatted with \`uv run ruff format\`.