### PR TITLE
feat(cli): add --version flag to beman-tidy (#269)

### DIFF
--- a/beman_tidy/cli.py
+++ b/beman_tidy/cli.py
@@ -3,9 +3,22 @@
 
 import argparse
 import sys
+from importlib.metadata import PackageNotFoundError, version
 
 from beman_tidy.lib.utils.git import get_repo_info, load_beman_standard_config
 from beman_tidy.lib.pipeline import run_checks_pipeline
+
+
+def _get_version() -> str:
+    """
+    Resolve the installed package version, falling back to ``"unknown"`` when
+    the distribution metadata is not discoverable (for example, when running
+    straight from a checkout without an editable install).
+    """
+    try:
+        return version("beman-tidy")
+    except PackageNotFoundError:
+        return "unknown"
 
 
 def parse_args():
@@ -14,6 +27,11 @@ def parse_args():
     """
 
     parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"beman-tidy {_get_version()}",
+    )
     parser.add_argument("repo_path", help="path to the repository to check", type=str)
     parser.add_argument(
         "--fix-inplace",


### PR DESCRIPTION
Closes #269.

Adds a `--version` flag to `beman-tidy` so users can confirm which version is on their PATH without having to shell out to `pipx list` or `pip show`. The flag resolves the version via `importlib.metadata.version("beman-tidy")`, so the output stays in sync with whatever is declared in `pyproject.toml` at build time.

Implementation notes:

- Registered the flag as a standard argparse `version` action at the top of `parse_args`, so it prints and exits before the required `repo_path` positional is parsed. That matches the issue's repro of `beman-tidy --version` failing with an "argument required" error today.
- Wrapped the metadata lookup in `_get_version()` and caught `PackageNotFoundError`, falling back to `"unknown"`. This keeps `--version` usable when the package is run straight from a checkout without an editable install (for example, by cloning this repo and executing `python -m beman_tidy.cli --version` before `pip install -e .`).

Verified locally with `pip install -e .` followed by `beman-tidy --version` — prints `beman-tidy 0.4.0`. `ruff check beman_tidy/cli.py` is clean and the existing test suite (`pytest tests/`) still passes (69 passed, 18 skipped).
