### PR TITLE
Added the python logger instead of the print function

### DIFF
--- a/beman_tidy/cli.py
+++ b/beman_tidy/cli.py
@@ -3,9 +3,11 @@
 
 import argparse
 import sys
+import logging
 
 from beman_tidy.lib.utils.git import get_repo_info, load_beman_standard_config
 from beman_tidy.lib.pipeline import run_checks_pipeline
+from beman_tidy.lib.utils.logger_config import setup_logging
 
 
 def parse_args():
@@ -51,11 +53,14 @@ def main():
     """
     The beman-tidy main entry point.
     """
+    setup_logging()
+    logger = logging.getLogger(__name__)
+
     args = parse_args()
 
     beman_standard_check_config = load_beman_standard_config()
     if not beman_standard_check_config or len(beman_standard_check_config) == 0:
-        print("Failed to download the beman standard. STOP.")
+        logger.info("Failed to download the beman standard. STOP.")
         return
 
     checks_to_run = (

--- a/beman_tidy/cli.py
+++ b/beman_tidy/cli.py
@@ -53,14 +53,12 @@ def main():
     """
     The beman-tidy main entry point.
     """
-    setup_logging()
-    logger = logging.getLogger(__name__)
 
     args = parse_args()
 
     beman_standard_check_config = load_beman_standard_config()
     if not beman_standard_check_config or len(beman_standard_check_config) == 0:
-        logger.info("Failed to download the beman standard. STOP.")
+        logging.error("Failed to download the beman standard. STOP.")
         return
 
     checks_to_run = (

--- a/beman_tidy/cli.py
+++ b/beman_tidy/cli.py
@@ -7,7 +7,6 @@ import logging
 
 from beman_tidy.lib.utils.git import get_repo_info, load_beman_standard_config
 from beman_tidy.lib.pipeline import run_checks_pipeline
-from beman_tidy.lib.utils.logger_config import setup_logging
 
 
 def parse_args():

--- a/beman_tidy/lib/checks/base/base_check.py
+++ b/beman_tidy/lib/checks/base/base_check.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 from abc import ABC
+import logging
 from pathlib import Path
 
 from ..system.registry import get_beman_standard_check_name_by_class
@@ -200,4 +201,4 @@ class BaseCheck(ABC):
                 else no_color
             )
 
-            print(f"[{color}{level}{no_color}][{self.name}]: {message}")
+            logging.info(f"[{color}{level}{no_color}][{self.name}]: {message}")

--- a/beman_tidy/lib/pipeline.py
+++ b/beman_tidy/lib/pipeline.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
 import sys
+import logging
 
 from .checks.system.registry import get_registered_beman_standard_checks
 from .checks.system.git import DisallowFixInplaceAndUnstagedChangesCheck
@@ -41,7 +42,7 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
         Helper function to log messages.
         """
         if args.verbose:
-            print(msg)
+            logging.info(msg)
 
     def run_check(check_class, log_enabled=args.verbose, require_all=args.require_all):
         """
@@ -174,10 +175,10 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
     log("\nbeman-tidy pipeline finished.\n")
 
     # Always print the summary.
-    print(
+    logging.info(
         f"Summary    Requirement: {green_color} {cnt_passed_checks['Requirement']} checks passed{no_color}, {red_color}{cnt_failed_checks['Requirement']} checks failed{no_color}, {gray_color}{cnt_skipped_checks['Requirement']} checks skipped, {no_color} {cnt_not_implemented_checks['Requirement']} checks not implemented."
     )
-    print(
+    logging.info(
         f"Summary Recommendation: {green_color} {cnt_passed_checks['Recommendation']} checks passed{no_color}, {red_color}{cnt_failed_checks['Recommendation']} checks failed{no_color}, {gray_color}{cnt_skipped_checks['Recommendation']} checks skipped, {no_color} {cnt_not_implemented_checks['Recommendation']} checks not implemented."
     )
 
@@ -223,17 +224,17 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
     )
     total_implemented = total_implemented_requirement + total_implemented_recommendation
     total_coverage = round((total_passed) / (total_implemented) * 100, 2)
-    print(
+    logging.info(
         f"\n{calculate_coverage_color(coverage_requirement)}Coverage    Requirement: {coverage_requirement:{6}.2f}% ({cnt_passed_requirement}/{total_implemented_requirement} checks passed).{no_color}"
     )
-    print(
+    logging.info(
         f"{calculate_coverage_color(coverage_recommendation, no_color=args.require_all)}Coverage Recommendation: {coverage_recommendation:{6}.2f}% ({cnt_passed_recommendation}/{total_implemented_recommendation} checks passed).{no_color}"
     )
-    print(
+    logging.info(
         f"{calculate_coverage_color(total_coverage)}Coverage          TOTAL: {total_coverage:{6}.2f}% ({total_passed}/{total_implemented} checks passed).{no_color}"
     )
     # else:
-    #     print("Note: RECOMMENDATIONs are not included (--require-all NOT set).")
+    #     logging.info("Note: RECOMMENDATIONs are not included (--require-all NOT set).")
     total_cnt_failed = cnt_failed_checks["Requirement"] + (
         cnt_failed_checks["Recommendation"] if args.require_all else 0
     )

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -3,9 +3,10 @@
 
 import sys
 import yaml
+import logging
+
 from pathlib import Path
 from beman_tidy.lib.utils.file import get_repo_ignorable_subdirectories
-
 
 def validate_config(config):
     """
@@ -18,25 +19,25 @@ def validate_config(config):
         return True
 
     if not isinstance(ignored_paths, list):
-        print(f"Error: 'ignored_paths' in .beman-tidy.yaml must be a list, but got {type(ignored_paths).__name__}.")
+        logging.error(f"Error: 'ignored_paths' in .beman-tidy.yaml must be a list, but got {type(ignored_paths).__name__}.")
         return False
 
     mandatory_files = {"README.md", "LICENSE"}
 
     for path in ignored_paths:
         if not isinstance(path, str):
-            print(f"Error: Invalid entry in 'ignored_paths': {path}. Must be a string.")
+            logging.error(f"Error: Invalid entry in 'ignored_paths': {path}. Must be a string.")
             return False
 
         clean_path = path.rstrip("/")
         # Check for exact match
         if clean_path in mandatory_files:
-             print(f"Error: Cannot ignore mandatory file '{clean_path}' in .beman-tidy.yaml")
+             logging.error(f"Error: Cannot ignore mandatory file '{clean_path}' in .beman-tidy.yaml")
              return False
         
         # Check if ignoring root directory
         if clean_path == "." or clean_path == "":
-             print("Error: Cannot ignore root directory in .beman-tidy.yaml")
+             logging.error("Error: Cannot ignore root directory in .beman-tidy.yaml")
              return False
              
     return True
@@ -71,10 +72,10 @@ def load_repo_config(repo_path, config_path=None):
             with open(user_config_path, "r") as f:
                 user_config = yaml.safe_load(f) or {}
         except Exception as e:
-            print(f"Error loading user configuration from '{user_config_path}': {e}")
+            logging.error(f"Error loading user configuration from '{user_config_path}': {e}")
             sys.exit(1)
     elif config_path:
-        print(f"Error: Configuration file specified not found at '{config_path}'")
+        logging.error(f"Error: Configuration file specified not found at '{config_path}'")
         sys.exit(1)
 
     # Merge configurations

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -7,6 +7,9 @@ import logging
 
 from pathlib import Path
 from beman_tidy.lib.utils.file import get_repo_ignorable_subdirectories
+from beman_tidy.lib.utils.logger_config import setup_logging
+
+setup_logging()
 
 def validate_config(config):
     """
@@ -39,7 +42,7 @@ def validate_config(config):
         if clean_path == "." or clean_path == "":
              logging.error("Error: Cannot ignore root directory in .beman-tidy.yaml")
              return False
-             
+        
     return True
 
 

--- a/beman_tidy/lib/utils/git.py
+++ b/beman_tidy/lib/utils/git.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import logging
 import re
 import sys
 import yaml
@@ -120,10 +121,10 @@ def get_repo_info(path: str, config_path: str = None):
             "config": config,
         }
     except InvalidGitRepositoryError:
-        print(f"The path '{path}' is not inside a valid Git repository.")
+        logging.error(f"The path '{path}' is not inside a valid Git repository.")
         sys.exit(1)
     except Exception:
-        print(f"An error occurred while getting repository information. Check {path}.")
+        logging.error(f"An error occurred while getting repository information. Check {path}.")
         sys.exit(1)
 
 

--- a/beman_tidy/lib/utils/logger_config.py
+++ b/beman_tidy/lib/utils/logger_config.py
@@ -1,0 +1,7 @@
+import logging
+
+def setup_logging():
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(message)s'
+    )

--- a/beman_tidy/lib/utils/logger_config.py
+++ b/beman_tidy/lib/utils/logger_config.py
@@ -1,7 +1,18 @@
 import logging
+import sys
+
+# an object that always redirects to the stdout stream
+class DynamicStdoutStream:
+    def write(self, data):
+        sys.stdout.write(data)
+    
+    def flush(self):
+        sys.stdout.flush()
 
 def setup_logging():
     logging.basicConfig(
         level=logging.INFO,
-        format='%(message)s'
+        format='%(message)s',
+        force=True,
+        stream=DynamicStdoutStream(),
     )

--- a/beman_tidy/lib/utils/terminal.py
+++ b/beman_tidy/lib/utils/terminal.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import logging
 import subprocess
 
 
@@ -10,7 +11,7 @@ def run_command(command, return_stdout=False, cwd=None):
     If return_stdout is True, return the stdout of the command.
     Optionally, change the current working directory to cwd.
     """
-    print(f"Running command: {command} with cwd: {cwd}")
+    logging.info(f"Running command: {command} with cwd: {cwd}")
     if return_stdout:
         bin = subprocess.Popen(
             command, shell=True, stdout=subprocess.PIPE, cwd=cwd

--- a/tests/utils/registry.py
+++ b/tests/utils/registry.py
@@ -5,6 +5,7 @@ import importlib
 import inspect
 from pathlib import Path
 import re
+import logging
 
 
 def find_pytest_test_functions_for_check(check_pattern):
@@ -57,7 +58,7 @@ def find_pytest_test_functions_for_check(check_pattern):
                             )
 
                 except Exception as e:
-                    print(f"Error loading module {test_file}: {e}")
+                    logging.error(f"Error loading module {test_file}: {e}")
 
     return test_functions
 


### PR DESCRIPTION
Issue: https://github.com/orgs/bemanproject/projects/8/views/1?pane=issue&itemId=115853175&issue=bemanproject%7Cbeman-tidy%7C30

Replaced print function with the python default loggger

Added a logger.config file in beman_tidy/lib/utils/config.py which sets up a global
configuration for the logger variable an import this module in the following files:
1. beman_tidy/cli.py
2. beman_tidy/pipeline.py
3. beman_tidy/lib/utils/config.py
4. tests/utils/registry.py

Before the PR:
```                    
print(f"Error loading module {test_file}: {e}")
```
After:
```
logging.error(f"Error loading module {test_file}: {e}")
```