### PR TITLE
ci: split run_on_exemplar into separate workflow file

### DIFF
--- a/.github/workflows/beman-tidy.yml
+++ b/.github/workflows/beman-tidy.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * *' #  09:00AM EEST (@neatudarius' timezone)
+    - cron: '0 6 * * *' # 09:00AM EEST
 
 jobs:
   run_linter:

--- a/.github/workflows/beman-tidy.yml
+++ b/.github/workflows/beman-tidy.yml
@@ -71,31 +71,7 @@ jobs:
           uv tool install --force dist/*.whl
           beman-tidy --help
 
-  run_on_exemplar:
-    name: Run on beman.exemplar
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v6
-        with:
-          enable-cache: true
-
-      - name: Build and install beman-tidy
-        run: |
-          uv build
-          uv tool install --force dist/*.whl
-          beman-tidy --help
-
-      - name: Run installed beman-tidy on exemplar repo
-        run: |
-          git clone https://github.com/bemanproject/exemplar.git
-          cd exemplar/ # Testing that beman-tidy can be run from any path, e.g. from the exemplar repo.
-          beman-tidy --verbose --require-all .
-
   create-issue-when-fault:
-    needs: [run_linter, run_tests, build_and_install, run_on_exemplar]
+    needs: [run_linter, run_tests, build_and_install]
     if: failure() && (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0

--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -1,0 +1,43 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Run on beman.exemplar
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+  workflow_call:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *' #  09:00AM EEST (@neatudarius' timezone)
+
+jobs:
+  run_on_exemplar:
+    name: Run on beman.exemplar
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Build and install beman-tidy
+        run: |
+          uv build
+          uv tool install --force dist/*.whl
+          beman-tidy --help
+
+      # - name: Run installed beman-tidy on exemplar repo
+      #   run: |
+      #     git clone https://github.com/bemanproject/exemplar.git
+      #     cd exemplar/ # Testing that beman-tidy can be run from any path, e.g. from the exemplar repo.
+      #     beman-tidy --verbose --require-all .
+
+  create-issue-when-fault:
+    needs: [run_on_exemplar]
+    if: failure() && (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0

--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -10,7 +10,7 @@ on:
   workflow_call:
   workflow_dispatch:
   schedule:
-    - cron: '0 6 * * *' #  09:00AM EEST (@neatudarius' timezone)
+    - cron: '0 6 * * *' # 09:00AM EEST
 
 jobs:
   run_on_exemplar:


### PR DESCRIPTION
## Summary

- Moves `run_on_exemplar` job out of `beman-tidy.yml` into a new dedicated `run-on-exemplar.yml` workflow
- `beman-tidy.yml` now covers: linter, tests, build & install
- `run-on-exemplar.yml` covers: exemplar-specific testing (with its own `create-issue-when-fault`)
- Easier to iterate on exemplar testing independently (see #266)

## Related

- #266 — CI tests against cookiecutter-generated library

## Test plan
- [x] `beman-tidy.yml` CI jobs pass (linter, tests, build)
- [x] `run-on-exemplar.yml` CI job appears and runs