### PR TITLE
Add CI flow: run beman-tidy on all Beman libraries (#267)

### DIFF
--- a/.github/workflows/run-on-all-libraries.yml
+++ b/.github/workflows/run-on-all-libraries.yml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Run on all Beman libraries
+
+on:
+  schedule:
+    - cron: '0 6 * * 0' # Weekly on Sunday 09:00 EEST
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  parse-libraries:
+    name: Parse Beman library list
+    runs-on: ubuntu-latest
+    outputs:
+      libraries: ${{ steps.parse.outputs.libraries }}
+    steps:
+      - name: Fetch libraries.md from bemanproject/website
+        run: |
+          curl -fsSL \
+            https://raw.githubusercontent.com/bemanproject/website/main/src/pages/libraries.md \
+            -o libraries.md
+
+      - name: Parse library repo names
+        id: parse
+        run: |
+          python3 - << 'EOF'
+          import re, json, os
+
+          with open("libraries.md") as f:
+              content = f.read()
+
+          # Excluded: exemplar (template repo, tested separately) and retired libs
+          excluded = {"exemplar", "dump"}
+
+          libs = []
+          for line in content.splitlines():
+              if "Retired" in line:
+                  continue
+              m = re.search(
+                  r'\[beman\.\w+\]\(https://github\.com/bemanproject/(\w+)\)', line
+              )
+              if m:
+                  repo = m.group(1)
+                  if repo not in excluded:
+                      libs.append(repo)
+
+          output = f"libraries={json.dumps(libs)}"
+          print(output)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as f:
+              f.write(output + "\n")
+          EOF
+
+  run-beman-tidy:
+    name: beman.${{ matrix.repo }}
+    needs: parse-libraries
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        repo: ${{ fromJson(needs.parse-libraries.outputs.libraries) }}
+    steps:
+      - name: Checkout beman-tidy
+        uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          enable-cache: true
+
+      - name: Build and install beman-tidy
+        run: |
+          uv build
+          uv tool install --force dist/*.whl
+          beman-tidy --version
+
+      - name: Clone beman.${{ matrix.repo }}
+        run: |
+          git clone --depth=1 https://github.com/bemanproject/${{ matrix.repo }}.git
+
+      - name: Run beman-tidy on beman.${{ matrix.repo }}
+        run: |
+          beman-tidy ${{ matrix.repo }}/
+          exit_code=$?
+          # Exit code 0: all checks passed
+          # Exit code 1: violations found (acceptable - libraries may have open violations)
+          # Exit code 2: beman-tidy crashed (bug in beman-tidy) -> fail
+          if [ $exit_code -eq 2 ]; then
+            echo "::error::beman-tidy crashed on beman.${{ matrix.repo }} (exit code 2)"
+            exit 1
+          fi
+          exit 0
+
+  create-issue-when-fault:
+    needs: [run-beman-tidy]
+    if: failure() && (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0


### PR DESCRIPTION
Closes #267.

## Summary

Adds `.github/workflows/run-on-all-libraries.yml` — a scheduled CI workflow that runs `beman-tidy` (default mode) against all active Beman libraries from [bemanproject/website/libraries.md](https://github.com/bemanproject/website/blob/main/src/pages/libraries.md).

## How it works

1. **`parse-libraries` job**: fetches `libraries.md` from `bemanproject/website` and parses it with Python to extract repo names, excluding:
   - `beman.exemplar` (template repo, tested separately in `run-on-exemplar.yml`)
   - Retired libraries (e.g. `beman.dump`)

2. **`beman.<repo>` jobs** (one per library, via matrix): 
   - Checks out and builds `beman-tidy` from the current commit
   - Clones the library with `--depth=1`
   - Runs `beman-tidy <repo>/` in default mode (requirements only)

## Exit code handling

| Exit code | Meaning | Job result |
|---|---|---|
| `0` | All checks passed | ✅ Pass |
| `1` | Violations found | ✅ Pass (acceptable — libraries may have open violations) |
| `2` | beman-tidy crashed | ❌ Fail |

Only crashes (`exit 2`) fail the job, making it easy to distinguish a `beman-tidy` bug from expected library violations.

## Trigger

- Weekly cron: every Sunday at 06:00 UTC (09:00 EEST)
- `workflow_dispatch` for manual runs
- `workflow_call` for reuse from other workflows

## Test plan

- [ ] Trigger `workflow_dispatch` and verify one job appears per library
- [ ] Verify `beman.exemplar` and `beman.dump` are excluded from the matrix
- [ ] Verify crashes (exit 2) fail the job; violations (exit 1) do not

🤖 Generated with [Claude Code](https://claude.com/claude-code)