### PR TITLE
implement file.license_id (#58)

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -3,7 +3,8 @@
 
 from ..base.file_base_check import FileBaseCheck, BatchFileBaseCheck
 from ..system.registry import register_beman_standard_check
-from ...utils.file import get_cpp_files, get_spdx_info
+from ...utils.file import get_cpp_files, get_spdx_info, get_commentable_files
+from ...utils.string import normalize_path_for_display
 from ...utils.comments import find_in_comment, CommentType, BLOCK_ENDS, BLOCK_STARTS, LINE_PREFIXES
 
 # [file.*] checks category.
@@ -16,7 +17,81 @@ from ...utils.comments import find_in_comment, CommentType, BLOCK_ENDS, BLOCK_ST
 # TODO file.test_names
 
 
-# TODO file.license_id
+@register_beman_standard_check("file.license_id")
+class FileLicenseIdCheck(BatchFileBaseCheck):
+    """
+    [file.license_id]
+    Requirement: The SPDX license identifier must be added at the first possible line
+    in all files which can contain a comment (C++, CMake, Python, shell, YAML, etc.).
+    """
+
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+        self.file_check_class = self.FileLicenseIdCheckImpl
+        self.file_path_generator = get_commentable_files
+
+    class FileLicenseIdCheckImpl(FileBaseCheck):
+        """
+        Implementation of the "file.license_id" check for a single file.
+        """
+
+        def __init__(self, repo_info, beman_standard_check_config, relative_path):
+            super().__init__(repo_info, beman_standard_check_config, relative_path, name="file.license_id")
+
+        def _expected_spdx_line_index(self, lines):
+            """
+            Returns the expected line index for the SPDX identifier.
+            If the first line is a shebang (#!), SPDX goes on line 1; otherwise line 0.
+            """
+            if lines and lines[0].startswith("#!"):
+                return 1
+            return 0
+
+        def check(self):
+            lines = self.read_lines()
+            spdx_index, _ = get_spdx_info(lines)
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+
+            if spdx_index == -1:
+                self.log(
+                    f"Missing SPDX-License-Identifier in {display_path}. "
+                    f"Please add it at the first line. "
+                    f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#filelicense_id"
+                )
+                return False
+
+            expected = self._expected_spdx_line_index(lines)
+            if spdx_index != expected:
+                self.log(
+                    f"SPDX-License-Identifier must be at line {expected + 1} in {display_path}, "
+                    f"but found at line {spdx_index + 1}. "
+                    f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#filelicense_id"
+                )
+                return False
+
+            return True
+
+        def fix(self):
+            lines = self.read_lines()
+            spdx_index, _ = get_spdx_info(lines)
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+
+            if spdx_index == -1:
+                self.log(
+                    f"Cannot auto-fix {display_path}: SPDX-License-Identifier is missing. "
+                    f"Please add it manually."
+                )
+                return False
+
+            expected = self._expected_spdx_line_index(lines)
+            if spdx_index == expected:
+                return True  # Already correct
+
+            # Move the SPDX line to the expected position
+            spdx_line = lines.pop(spdx_index)
+            lines.insert(expected, spdx_line)
+            self.write("".join(lines))
+            return True
 
 
 @register_beman_standard_check("file.copyright")

--- a/beman_tidy/lib/utils/file.py
+++ b/beman_tidy/lib/utils/file.py
@@ -98,6 +98,53 @@ def get_beman_include_headers(repo_path, ignores=None):
     return beman_headers
 
 
+COMMENTABLE_EXTENSIONS = {
+    # C++
+    ".cpp", ".hpp", ".h", ".hxx", ".cxx", ".cc",
+    # CMake
+    ".cmake",
+    # Python
+    ".py",
+    # Shell
+    ".sh",
+    # YAML/YML
+    ".yml", ".yaml",
+}
+
+COMMENTABLE_FILENAMES = {
+    "CMakeLists.txt",
+    "Dockerfile",
+}
+
+
+def get_commentable_files(repo_path, ignores=None):
+    """
+    Get all files that can contain a comment (and thus should have an SPDX identifier).
+    Covers C++, CMake, Python, shell scripts, and YAML files.
+    """
+    if ignores is None:
+        ignores = get_repo_ignorable_subdirectories()
+
+    matched_files = []
+    repo_path = Path(repo_path)
+
+    for root, dirs, files in os.walk(repo_path):
+        rel_root = Path(root).relative_to(repo_path)
+
+        for d in list(dirs):
+            d_path = rel_root / d
+            if _is_ignored(d_path, ignores):
+                dirs.remove(d)
+
+        for f in files:
+            f_path = rel_root / f
+            if f_path.suffix in COMMENTABLE_EXTENSIONS or f_path.name in COMMENTABLE_FILENAMES:
+                if not _is_ignored(f_path, ignores):
+                    matched_files.append(f_path)
+
+    return sorted(list(set(matched_files)))
+
+
 def get_spdx_info(lines):
     """
     Helper to find the SPDX line index and the comment info.

--- a/tests/lib/checks/beman_standard/file/data/license_id/invalid_missing/no_spdx.cmake
+++ b/tests/lib/checks/beman_standard/file/data/license_id/invalid_missing/no_spdx.cmake
@@ -1,0 +1,3 @@
+# No license identifier here
+
+cmake_minimum_required(VERSION 3.23)

--- a/tests/lib/checks/beman_standard/file/data/license_id/invalid_missing/no_spdx.cpp
+++ b/tests/lib/checks/beman_standard/file/data/license_id/invalid_missing/no_spdx.cpp
@@ -1,0 +1,5 @@
+// Copyright 2026 Beman Project
+
+#include <iostream>
+
+int main() { return 0; }

--- a/tests/lib/checks/beman_standard/file/data/license_id/invalid_wrong_line/wrong_line.cpp
+++ b/tests/lib/checks/beman_standard/file/data/license_id/invalid_wrong_line/wrong_line.cpp
@@ -1,0 +1,5 @@
+// Some comment first
+
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <iostream>

--- a/tests/lib/checks/beman_standard/file/data/license_id/invalid_wrong_line/wrong_line.sh
+++ b/tests/lib/checks/beman_standard/file/data/license_id/invalid_wrong_line/wrong_line.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Some comment before SPDX
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+echo "hello"

--- a/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.cmake
+++ b/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.cmake
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.23)

--- a/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.cpp
+++ b/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.cpp
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#include <iostream>
+
+int main() { return 0; }

--- a/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.hpp
+++ b/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.hpp
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+#pragma once
+
+namespace beman::example {}

--- a/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.sh
+++ b/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+echo "hello"

--- a/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.yml
+++ b/tests/lib/checks/beman_standard/file/data/license_id/valid/valid.yml
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+name: Example workflow

--- a/tests/lib/checks/beman_standard/file/test_file.py
+++ b/tests/lib/checks/beman_standard/file/test_file.py
@@ -4,10 +4,11 @@
 import shutil
 from pathlib import Path
 
-from beman_tidy.lib.checks.beman_standard.file import FileCopyrightCheck
+from beman_tidy.lib.checks.beman_standard.file import FileCopyrightCheck, FileLicenseIdCheck
 
 # Workaround to test for both normal and block comments.
 test_data_prefix = Path("tests/lib/checks/beman_standard/file/data")
+license_id_prefix = test_data_prefix / "license_id"
 valid_prefix = test_data_prefix / "valid"
 invalid_prefix = test_data_prefix / "invalid"
 valid_block_prefix = test_data_prefix / "valid_block"
@@ -89,3 +90,56 @@ def test__file_copyright__fix_inplace(repo_info, beman_standard_check_config, tm
             stripped = line.strip()
             if stripped.startswith("/*") or stripped.startswith("*"):
                 assert "Copyright" not in line, f"Copyright still present in {fixed_file.name}: {line}"
+
+# --- file.license_id tests ---
+
+def test__file_license_id__valid(repo_info, beman_standard_check_config):
+    repo_info["top_level"] = license_id_prefix / "valid"
+    check = FileLicenseIdCheck(repo_info, beman_standard_check_config)
+    assert check.check() is True
+
+
+def test__file_license_id__invalid(repo_info, beman_standard_check_config):
+    # Missing SPDX entirely
+    repo_info["top_level"] = license_id_prefix / "invalid_missing"
+    check = FileLicenseIdCheck(repo_info, beman_standard_check_config)
+    assert check.check() is False
+
+    # SPDX present but not at the first possible line
+    repo_info["top_level"] = license_id_prefix / "invalid_wrong_line"
+    check = FileLicenseIdCheck(repo_info, beman_standard_check_config)
+    assert check.check() is False
+
+
+def test__file_license_id__fix_inplace(repo_info, beman_standard_check_config, tmp_path):
+    # Fix: SPDX at wrong line → move to first line
+    src = license_id_prefix / "invalid_wrong_line"
+    dst = tmp_path / "invalid_wrong_line"
+    shutil.copytree(src, dst)
+
+    repo_info["top_level"] = dst
+    check = FileLicenseIdCheck(repo_info, beman_standard_check_config)
+
+    assert check.check() is False
+    assert check.fix() is True
+    assert check.check() is True
+
+    for f in dst.iterdir():
+        if not f.is_file():
+            continue
+        lines = f.read_text().splitlines()
+        if lines and lines[0].startswith("#!"):
+            assert "SPDX-License-Identifier:" in lines[1], f"SPDX not at line 2 in {f.name}"
+        else:
+            assert "SPDX-License-Identifier:" in lines[0], f"SPDX not at line 1 in {f.name}"
+
+    # Fix: SPDX missing → cannot auto-fix
+    src = license_id_prefix / "invalid_missing"
+    dst = tmp_path / "invalid_missing"
+    shutil.copytree(src, dst)
+
+    repo_info["top_level"] = dst
+    check = FileLicenseIdCheck(repo_info, beman_standard_check_config)
+
+    assert check.check() is False
+    assert check.fix() is False


### PR DESCRIPTION
Closes #58.

## Summary

Implements the `[file.license_id]` check from the Beman Standard:

> The SPDX license identifier must be added at the **first possible line** in all files which can contain a comment (C++, CMake, Python, shell, YAML, etc.).

## Changes

### `beman_tidy/lib/utils/file.py`
- Added `get_commentable_files()` — discovers all files that should have an SPDX identifier (`.cpp`, `.hpp`, `.h`, `.hxx`, `.cxx`, `.cc`, `.cmake`, `.py`, `.sh`, `.yml`, `.yaml`, `CMakeLists.txt`, `Dockerfile`)

### `beman_tidy/lib/checks/beman_standard/file.py`
- Added `FileLicenseIdCheck` (`BatchFileBaseCheck`)
  - **`check()`**: verifies SPDX is present AND at the correct line (line 0, or line 1 if a shebang is on line 0)
  - **`fix()`**: moves SPDX to the correct position if misplaced; logs an error if missing (can't auto-fix)

## Test data

| Directory | Content |
|---|---|
| `valid/` | `.cpp`, `.hpp`, `.cmake`, `.sh` (with shebang), `.yml` — all with SPDX at line 0/1 |
| `invalid_missing/` | `.cpp`, `.cmake` — no SPDX at all |
| `invalid_wrong_line/` | `.cpp`, `.sh` — SPDX present but not at first line |

## Test plan

- [x] `test__file_license_id__valid` — passes on correct files
- [x] `test__file_license_id__invalid` — fails on missing SPDX and wrong-line SPDX
- [x] `test__file_license_id__fix_inplace` — moves SPDX to correct line; reports unfixable when missing
- [x] Full test suite: 72 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)