### PR TITLE
Re-enable running beman-tidy on exemplar

### DIFF
--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -31,11 +31,11 @@ jobs:
           uv tool install --force dist/*.whl
           beman-tidy --help
 
-      # - name: Run installed beman-tidy on exemplar repo
-      #   run: |
-      #     git clone https://github.com/bemanproject/exemplar.git
-      #     cd exemplar/ # Testing that beman-tidy can be run from any path, e.g. from the exemplar repo.
-      #     beman-tidy --verbose --require-all .
+      - name: Run installed beman-tidy on exemplar repo
+        run: |
+          git clone https://github.com/bemanproject/exemplar.git
+          cd exemplar/ # Testing that beman-tidy can be run from any path, e.g. from the exemplar repo.
+          beman-tidy --verbose --require-all .
 
   create-issue-when-fault:
     needs: [run_on_exemplar]


### PR DESCRIPTION
closes #241

undoing #276 in preparation of bemanproject/exemplar#368

with the latest disabling of rules feature on tidy in #279 we should be able to test on exemplar again, even if it has slightly deviated from the standard.