### PR TITLE
Make checks ignore build artifacts

### DIFF
--- a/beman_tidy/lib/utils/file.py
+++ b/beman_tidy/lib/utils/file.py
@@ -10,7 +10,20 @@ def get_repo_ignorable_subdirectories():
     """
     Returns a set of common build and IDE directories to ignore.
     """
-    return {".git/", "build/", ".idea/", ".vscode/", "__pycache__/", "venv/", "env/"}
+    return {
+        ".git/",
+        "build/",
+        "cmake-build-debug/",
+        "cmake-build-release/",
+        ".idea/",
+        ".vscode/",
+        "__pycache__/",
+        ".pytest_cache/",
+        ".ruff_cache/",
+        "node_modules/",
+        "venv/",
+        "env/",
+    }
 
 
 def get_cpp_header_extensions():


### PR DESCRIPTION
fixes #301, making file.license_id pass on exemplar (and future checks that will accidentally target artifacts)

```
Running check [Requirement][file.license_id] ... 
        check [Requirement][file.license_id] ... passed
```
(this was run on my local fork of exemplar which has all its non-artifact missing license ids added back - bemanproject/exemplar#375)