### PR TITLE
Implement file.names

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -11,7 +11,51 @@ from ...utils.comments import find_in_comment, CommentType, BLOCK_ENDS, BLOCK_ST
 # All checks in this file extend the BaseCheck class.
 
 
-# TODO file.names
+@register_beman_standard_check("file.names")
+class FileNamesCheck(BatchFileBaseCheck):
+    """
+    [file.names]
+    Requirement: File names must be lowercase and use snake_case.
+    """
+
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+        self.file_check_class = self.FileNamesCheckImpl
+        self.file_path_generator = get_cpp_files
+
+    class FileNamesCheckImpl(FileBaseCheck):
+        """
+        Implementation of the "file.names" check for a single file.
+        """
+
+        def __init__(self, repo_info, beman_standard_check_config, relative_path):
+            super().__init__(
+                repo_info, beman_standard_check_config, relative_path, name="file.names"
+            )
+
+        def check(self):
+            filename_stem = self.path.stem
+
+            # lowercase and snake_case
+            is_valid = (not filename_stem or filename_stem.islower() or filename_stem.isdigit()) and all(
+                c.isalnum() or c == "_" for c in filename_stem
+            )
+
+            if not is_valid:
+                display_path = normalize_path_for_display(self.path, self.repo_path)
+                self.log(
+                    f"File name {display_path} does not follow the snake_case naming convention. "
+                    f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#filenames"
+                )
+                return False
+            return True
+
+        def fix(self):
+            display_path = normalize_path_for_display(self.path, self.repo_path)
+            self.log(
+                f"Please manually rename {display_path} to follow the snake_case naming convention."
+            )
+            return False
 
 
 # TODO file.test_names

--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -15,7 +15,7 @@ from ...utils.comments import find_in_comment, CommentType, BLOCK_ENDS, BLOCK_ST
 class FileNamesCheck(BatchFileBaseCheck):
     """
     [file.names]
-    Requirement: File names must be lowercase and use snake_case.
+    Recommendation: File names must be lowercase and use snake_case.
     """
 
     def __init__(self, repo_info, beman_standard_check_config):

--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -37,7 +37,7 @@ class FileNamesCheck(BatchFileBaseCheck):
             filename_stem = self.path.stem
 
             # lowercase and snake_case
-            is_valid = (not filename_stem or filename_stem.islower() or filename_stem.isdigit()) and all(
+            is_valid = filename_stem == filename_stem.lower() and all(
                 c.isalnum() or c == "_" for c in filename_stem
             )
 

--- a/tests/lib/checks/beman_standard/file/data/names/invalid/MyFile.cpp
+++ b/tests/lib/checks/beman_standard/file/data/names/invalid/MyFile.cpp
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+int main() {}

--- a/tests/lib/checks/beman_standard/file/data/names/invalid/my-file.hpp
+++ b/tests/lib/checks/beman_standard/file/data/names/invalid/my-file.hpp
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+int main() {}

--- a/tests/lib/checks/beman_standard/file/data/names/valid/identity.hpp
+++ b/tests/lib/checks/beman_standard/file/data/names/valid/identity.hpp
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+int main() {}

--- a/tests/lib/checks/beman_standard/file/data/names/valid/my_file.cpp
+++ b/tests/lib/checks/beman_standard/file/data/names/valid/my_file.cpp
@@ -1,0 +1,2 @@
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+int main() {}

--- a/tests/lib/checks/beman_standard/file/test_file.py
+++ b/tests/lib/checks/beman_standard/file/test_file.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 
+import pytest
 import shutil
 from pathlib import Path
 
-from beman_tidy.lib.checks.beman_standard.file import FileCopyrightCheck, FileLicenseIdCheck
+from beman_tidy.lib.checks.beman_standard.file import FileCopyrightCheck, FileLicenseIdCheck, FileNamesCheck
 
 # Workaround to test for both normal and block comments.
 test_data_prefix = Path("tests/lib/checks/beman_standard/file/data")
@@ -143,3 +144,25 @@ def test__file_license_id__fix_inplace(repo_info, beman_standard_check_config, t
 
     assert check.check() is False
     assert check.fix() is False
+
+
+# --- file.names tests ---
+
+file_names_prefix = Path("tests/lib/checks/beman_standard/file/data/names")
+
+
+def test__file_names__valid(repo_info, beman_standard_check_config):
+    repo_info["top_level"] = file_names_prefix / "valid"
+    check = FileNamesCheck(repo_info, beman_standard_check_config)
+    assert check.check() is True
+
+
+def test__file_names__invalid(repo_info, beman_standard_check_config):
+    repo_info["top_level"] = file_names_prefix / "invalid"
+    check = FileNamesCheck(repo_info, beman_standard_check_config)
+    assert check.check() is False
+
+
+@pytest.mark.skip(reason="not implemented")
+def test__file_names__fix_inplace(repo_info, beman_standard_check_config):
+    pass


### PR DESCRIPTION
#42
This implements file.names for --dry-run. No fix-inplace, renaming the files automatically would cause problems in build system - same as file.test_names #305