### PR TITLE
fix(file.names): handle compound extensions like .test.cpp

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/file.py
+++ b/beman_tidy/lib/checks/beman_standard/file.py
@@ -34,7 +34,9 @@ class FileNamesCheck(BatchFileBaseCheck):
             )
 
         def check(self):
-            filename_stem = self.path.stem
+            # Use only the base name before the first dot to handle compound
+            # extensions like ".test.cpp" (e.g. "identity.test.cpp" -> "identity").
+            filename_stem = self.path.name.split(".")[0]
 
             # lowercase and snake_case
             is_valid = filename_stem == filename_stem.lower() and all(


### PR DESCRIPTION
## Summary

`file.names` check uses `Path.stem` to get the filename base, but `Path.stem` only strips the **last** suffix:

```python
Path("identity.test.cpp").stem  # → "identity.test"  ❌
```

The stem `"identity.test"` contains a dot, which fails the snake_case validation (`all(c.isalnum() or c == "_" ...)`), producing a false positive for files following the `.test.cpp` convention used throughout Beman projects.

**Fix**: split on the first dot to get the true base name:

```python
Path("identity.test.cpp").name.split(".")[0]  # → "identity"  ✓
```

## Examples

| File | Before (stem) | After (base) | Valid |
|------|--------------|--------------|-------|
| `identity.test.cpp` | `identity.test` ❌ | `identity` ✓ | True |
| `iterator_interface.test.cpp` | `iterator_interface.test` ❌ | `iterator_interface` ✓ | True |
| `MyClass.hpp` | `MyClass` | `MyClass` | False |
| `snake_case.hpp` | `snake_case` | `snake_case` | True |

## Test plan

- [ ] `identity.test.cpp` no longer flagged as invalid
- [ ] `MyClass.hpp` still correctly flagged as invalid
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)