### PR TITLE
ci: make run-on-exemplar run on template output

### DIFF
--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -39,6 +39,7 @@ jobs:
           git config user.name "GitHub Actions"
           ./stamp.sh project_name="cookiecutter_test" description="Test project" --no-input
           git remote remove origin
+          sed -i '/disabled_rules:/a \  - release.godbolt_trunk_version\n  - readme.implements\n  - file.names' .beman-tidy.yaml
           cd ..
           mv exemplar_repo cookiecutter_test
           cd cookiecutter_test

--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -31,10 +31,14 @@ jobs:
           uv tool install --force dist/*.whl
           beman-tidy --help
 
-      - name: Run installed beman-tidy on exemplar repo
+      - name: Run installed beman-tidy on cookiecutter output
         run: |
-          git clone https://github.com/bemanproject/exemplar.git
-          cd exemplar/ # Testing that beman-tidy can be run from any path, e.g. from the exemplar repo.
+          git clone --depth=1 https://github.com/bemanproject/exemplar.git exemplar_repo
+          cd exemplar_repo
+          ./stamp.sh project_name="cookiecutter_test" description="Test project" --no-input
+          cd ..
+          mv exemplar_repo cookiecutter_test
+          cd cookiecutter_test
           beman-tidy --verbose --require-all .
 
   create-issue-when-fault:

--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -38,6 +38,7 @@ jobs:
           git config user.email "actions@github.com"
           git config user.name "GitHub Actions"
           ./stamp.sh project_name="cookiecutter_test" description="Test project" --no-input
+          git remote remove origin
           cd ..
           mv exemplar_repo cookiecutter_test
           cd cookiecutter_test

--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -35,6 +35,8 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/bemanproject/exemplar.git exemplar_repo
           cd exemplar_repo
+          git config user.email "actions@github.com"
+          git config user.name "GitHub Actions"
           ./stamp.sh project_name="cookiecutter_test" description="Test project" --no-input
           cd ..
           mv exemplar_repo cookiecutter_test

--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -39,7 +39,7 @@ jobs:
           git config user.name "GitHub Actions"
           ./stamp.sh project_name="cookiecutter_test" description="Test project" --no-input
           git remote remove origin
-          sed -i '/disabled_rules:/a \  - release.godbolt_trunk_version\n  - readme.implements\n  - file.names' .beman-tidy.yaml
+          sed -i '/disabled_rules:/a \  - release.godbolt_trunk_version\n  - readme.implements' .beman-tidy.yaml
           cd ..
           mv exemplar_repo cookiecutter_test
           cd cookiecutter_test


### PR DESCRIPTION
fixes #241 (attempt 2!)
> Goal: Add beman-tidy into CI precommit hooks for generate libraries from beman.examplar (that means only inside the cookiecutter directory - as discussed with @ednolan).