### PR TITLE
Add '--list-checks' flag that lists all implemented checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,22 @@ beman-tidy --help
 
 ```shell
 $ beman-tidy --help
-usage: beman-tidy [-h] [--fix-inplace | --no-fix-inplace] [--verbose | --no-verbose] [--require-all | --no-require-all] [--checks CHECKS] [--config CONFIG] repo_path
+usage: beman-tidy [-h] [--version] [--fix-inplace | --no-fix-inplace] [--verbose | --no-verbose] [--require-all | --no-require-all] [--list-checks] [--checks CHECKS] [--config CONFIG]
+                  repo_path
 
 positional arguments:
   repo_path             path to the repository to check
 
 options:
   -h, --help            show this help message and exit
+  --version             show program's version number and exit
   --fix-inplace, --no-fix-inplace
-                        Try to automatically fix found issues
+                        try to automatically fix found issues
   --verbose, --no-verbose
                         print verbose output for each check
   --require-all, --no-require-all
-                        all checks are required regardless of the check type (e.g., Recommendation becomes Requirement)
+                        all checks are required regardless of their type (e.g., all RECOMMENDATIONs become REQUIREMENTs)
+  --list-checks         list all implemented checks
   --checks CHECKS       array of checks to run
   --config CONFIG       path to the configuration file (default: .beman-tidy.yaml in repo root)
 ```

--- a/beman_tidy/cli.py
+++ b/beman_tidy/cli.py
@@ -8,6 +8,39 @@ import logging
 
 from beman_tidy.lib.utils.git import get_repo_info, load_beman_standard_config
 from beman_tidy.lib.pipeline import run_checks_pipeline
+from beman_tidy.lib.checks.system.registry import get_registered_beman_standard_checks
+
+
+def list_checks(beman_standard_check_config):
+    """
+    Print all implemented beman-tidy checks.
+    """
+    implemented_checks = get_registered_beman_standard_checks()
+
+    for check_name in sorted(implemented_checks):
+        check_type = beman_standard_check_config.get(check_name, {}).get("type", "Unknown")
+        print(f"[{check_type}]".ljust(16), check_name)
+
+
+class ListChecksAction(argparse.Action):
+    """
+    Argparse action that lists implemented checks and exits.
+    """
+    def __init__(self, option_strings, dest, **kwargs):
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=0,
+            **kwargs,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        beman_standard_check_config = load_beman_standard_config()
+        if not beman_standard_check_config or len(beman_standard_check_config) == 0:
+            parser.exit(status=1, message="Failed to download the beman standard. STOP.\n")
+
+        list_checks(beman_standard_check_config)
+        parser.exit()
 
 
 def parse_args():
@@ -41,7 +74,15 @@ def parse_args():
         default=False,
     )
     parser.add_argument(
-        "--checks", help="array of checks to run", type=str, default=None
+        "--list-checks",
+        help="list all implemented checks",
+        action=ListChecksAction,
+    )
+    parser.add_argument(
+        "--checks",
+        help="array of checks to run",
+        type=str,
+        default=None,
     )
     parser.add_argument(
         "--config",

--- a/beman_tidy/cli.py
+++ b/beman_tidy/cli.py
@@ -37,7 +37,7 @@ class ListChecksAction(argparse.Action):
     def __call__(self, parser, namespace, values, option_string=None):
         beman_standard_check_config = load_beman_standard_config()
         if not beman_standard_check_config or len(beman_standard_check_config) == 0:
-            parser.exit(status=1, message="Failed to download the beman standard. STOP.\n")
+            parser.exit(status=1, message="Failed to load the Beman Standard configuration.\n")
 
         list_checks(beman_standard_check_config)
         parser.exit()
@@ -54,7 +54,11 @@ def parse_args():
         action="version",
         version=f"beman-tidy {_pkg_version('beman-tidy')}",
     )
-    parser.add_argument("repo_path", help="path to the repository to check", type=str)
+    parser.add_argument(
+        "repo_path",
+        help="path to the repository to check; required unless --list-checks is used",
+        type=str
+    )
     parser.add_argument(
         "--fix-inplace",
         help="try to automatically fix found issues",


### PR DESCRIPTION
Usage example:
```
$ beman-tidy --list-checks
[Requirement]    cmake.library_alias
[Recommendation] cmake.library_name
[Recommendation] cmake.project_name
[Recommendation] cpp.extension_identifiers
[Recommendation] cpp.namespace
[Requirement]    directory.docs
[Requirement]    directory.examples
[Requirement]    directory.papers
[Requirement]    directory.sources
[Requirement]    directory.tests
[Recommendation] file.copyright
[Requirement]    file.license_id
[Recommendation] file.names
[Requirement]    file.test_names
[Recommendation] library.name
[Recommendation] license.apache_llvm
[Requirement]    license.approved
[Requirement]    license.criteria
[Requirement]    readme.badges
[Recommendation] readme.implements
[Requirement]    readme.library_status
[Requirement]    readme.license
[Recommendation] readme.purpose
[Recommendation] readme.title
[Requirement]    release.github
[Recommendation] release.godbolt_trunk_version
[Recommendation] release.notes
[Requirement]    repository.code_review_rules
[Requirement]    repository.codeowners
[Requirement]    repository.default_branch
[Recommendation] repository.disallow_git_submodules
[Requirement]    repository.name
[Requirement]    toplevel.cmake
[Requirement]    toplevel.license
[Requirement]    toplevel.readme
```

`$ beman-tidy --list-checks /path/to/repo` outputs the same