### PR TITLE
Make readme.implements accept pre-wg21.link links

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/readme.py
+++ b/beman_tidy/lib/checks/beman_standard/readme.py
@@ -125,7 +125,7 @@ class ReadmeImplementsCheck(ReadmeBaseCheck):
         # **Implements**: [Give *std::optional* Range Support (P3168R2)](https://wg21.link/p3168r2) and [`std::optional<T&>` (p2988r5)](https://wg21.link/P2988R5)
         # **Implements**: [.... (P0000)](https://wg21.link/p0000), [.... (P1111R1)](https://wg21.link/p1111r1), and [.... (P2222)](https://wg21.link/p2222),
 
-        regex = r"^\*\*Implements\*\*:\s+.*\b[pP]\d{4}(?:[rR]\d+)?\b.*wg21\.link/[pP]\d{4}(?:[rR]\d+)?\b"
+        regex = r"^\*\*Implements\*\*:\s+.*\b[pP]\d{4}(?:[rR]\d+)?\b.*(?:wg21\.link|isocpp\.org/files/papers)/[pP]\d{4}(?:[rR]\d+)?\b"
         # Count the number of lines that match the regex
         implement_lines = 0
         for line in lines:

--- a/tests/lib/checks/beman_standard/readme/data/invalid/invalid-implements-v5.md
+++ b/tests/lib/checks/beman_standard/readme/data/invalid/invalid-implements-v5.md
@@ -1,0 +1,21 @@
+# beman.exemplar: A Beman Library Exemplar
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+<!-- markdownlint-disable line-length -->
+[![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#the-beman-library-maturity-model)
+[![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg)](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml)
+[![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml)
+<!-- markdownlint-restore -->
+
+<!-- markdownlint-disable-next-line line-length -->
+
+`beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern C++ project structure.
+
+**Implements**: [Timed lock algorithms for multiple lockables](https://isocpp.org/files/papers/P3832R3.html).
+
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
+
+<!-- markdownlint-disable-next-line line-length -->
+
+This is NOT a valid README.md according to the Beman Standard: missing P number in the link text while using isocpp.org URL.

--- a/tests/lib/checks/beman_standard/readme/data/valid/README-v6.md
+++ b/tests/lib/checks/beman_standard/readme/data/valid/README-v6.md
@@ -1,0 +1,26 @@
+# beman.exemplar: A Beman Library Exemplar
+
+<!-- SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception -->
+
+<!-- markdownlint-disable line-length -->
+[![Library Status](https://raw.githubusercontent.com/bemanproject/beman/refs/heads/main/images/badges/beman_badge-beman_library_under_development.svg)](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#the-beman-library-maturity-model)
+[![Continuous Integration Tests](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml/badge.svg)](https://github.com/bemanproject/exemplar/actions/workflows/ci_tests.yml)
+[![Lint Check (pre-commit)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml/badge.svg)](https://github.com/bemanproject/exemplar/actions/workflows/pre-commit.yml)
+![Standard Target](https://github.com/bemanproject/beman/blob/main/images/badges/cpp26.svg)
+<!-- markdownlint-restore -->
+
+<!-- markdownlint-disable-next-line line-length -->
+`beman.exemplar` is a minimal C++ library conforming to [The Beman Standard](https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md). This can be used as a template for those intending to write Beman libraries. It may also find use as a minimal and modern  C++ project structure.
+
+**Implements**: [Timed lock algorithms for multiple lockables (P3832)](https://isocpp.org/files/papers/P3832R3.html) and [`std::multi_lock` (P3833)](https://isocpp.org/files/papers/P3833R3.html).
+
+**Status**: [Under development and not yet ready for production use.](https://github.com/bemanproject/beman/blob/main/docs/beman_library_maturity_model.md#under-development-and-not-yet-ready-for-production-use)
+
+## License
+
+This project is licensed under the Apache License 2.0 with LLVM Exceptions.
+
+## Other
+
+<!-- markdownlint-disable-next-line line-length -->
+This is a valid README.md file that follows the Beman Standard: the implements uses isocpp.org/files/papers/ links instead of wg21.link.

--- a/tests/lib/checks/beman_standard/readme/test_readme.py
+++ b/tests/lib/checks/beman_standard/readme/test_readme.py
@@ -172,6 +172,7 @@ def test__readme_implements__valid(repo_info, beman_standard_check_config):
         Path(f"{valid_prefix}/README-v3.md"),
         Path(f"{valid_prefix}/README-v4.md"),
         Path(f"{valid_prefix}/README-v5.md"),
+        Path(f"{valid_prefix}/README-v6.md"),
     ]
 
     run_check_for_each_path(
@@ -193,6 +194,7 @@ def test__readme_implements__invalid(repo_info, beman_standard_check_config):
         Path(f"{invalid_prefix}/invalid-implements-v2.md"),
         Path(f"{invalid_prefix}/invalid-implements-v3.md"),
         Path(f"{invalid_prefix}/invalid-implements-v4.md"),
+        Path(f"{invalid_prefix}/invalid-implements-v5.md"),
     ]
 
     run_check_for_each_path(


### PR DESCRIPTION
A link like https://isocpp.org/files/papers/P3832R3.html will also be accepted.

Fixes #327