### PR TITLE
Fix for Commented-out code

### DIFF
--- a/beman_tidy/lib/pipeline.py
+++ b/beman_tidy/lib/pipeline.py
@@ -301,8 +301,6 @@ def run_checks_pipeline(checks_to_run, args, beman_standard_check_config):
         f"({total_passed}/{total_implemented} checks passed){disabled_total_coverage_suffix}.{no_color}"
     )
 
-    # else:
-    #     logging.info("Note: RECOMMENDATIONs are not included (--require-all NOT set).")
     total_cnt_failed = cnt_failed_checks["Requirement"] + (
         cnt_failed_checks["Recommendation"] if args.require_all else 0
     )


### PR DESCRIPTION
The best fix is to remove the commented-out code block at lines 304–305, since it is not executable and does not provide essential documentation beyond what the active logic already expresses (`args.require_all` controls recommendation handling). This preserves existing functionality exactly while improving readability and satisfying the CodeQL rule.

**Change location:** `beman_tidy/lib/pipeline.py`, around lines 304–306 in the shown snippet.

**What to change:** delete:
- `# else:`
- `#     logging.info("Note: RECOMMENDATIONs are not included (--require-all NOT set).")`

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._