### PR TITLE
ci: detect beman-tidy mode per library in run-on-all workflow

### DIFF
--- a/.github/scripts/detect_beman_tidy_mode.py
+++ b/.github/scripts/detect_beman_tidy_mode.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Detect how beman-tidy should run for a Beman library repository."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+_BEMAN_TIDY_HOOK_RE = re.compile(r"id:\s*beman-tidy\b")
+_REQUIRE_ALL_RE = re.compile(r"--require-all\b")
+
+
+def has_beman_tidy_hook(content: str) -> bool:
+    return _BEMAN_TIDY_HOOK_RE.search(content) is not None
+
+
+def uses_require_all(content: str) -> bool:
+    return has_beman_tidy_hook(content) and _REQUIRE_ALL_RE.search(content) is not None
+
+
+def detect_mode(repo_path: Path) -> str:
+    """
+    Return the beman-tidy invocation mode for a library repo.
+
+    - ``require-all``: pre-commit configures the beman-tidy hook with ``--require-all``.
+    - ``default``: no beman-tidy hook, or hook without ``--require-all``.
+    """
+    precommit = repo_path / ".pre-commit-config.yaml"
+    if not precommit.is_file():
+        return "default"
+
+    content = precommit.read_text(encoding="utf-8", errors="ignore")
+    if not has_beman_tidy_hook(content):
+        return "default"
+    if uses_require_all(content):
+        return "require-all"
+    return "default"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo_path", type=Path, help="Path to cloned library repository")
+    args = parser.parse_args()
+    print(detect_mode(args.repo_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/run-on-all-libraries.yml
+++ b/.github/workflows/run-on-all-libraries.yml
@@ -80,12 +80,23 @@ jobs:
 
       - name: Run beman-tidy on beman.${{ matrix.repo }}
         run: |
-          beman-tidy --verbose ${{ matrix.repo }}/
+          MODE=$(python3 .github/scripts/detect_beman_tidy_mode.py "${{ matrix.repo }}")
+          echo "Using beman-tidy mode: ${MODE} for beman.${{ matrix.repo }}"
+
+          ARGS=(--verbose)
+          if [ "${MODE}" = "require-all" ]; then
+            ARGS+=(--require-all)
+          fi
+
+          set +e
+          beman-tidy "${ARGS[@]}" "${{ matrix.repo }}/"
           exit_code=$?
+          set -e
+
           # Exit code 0: all checks passed
           # Exit code 1: violations found (acceptable - libraries may have open violations)
           # Exit code 2: beman-tidy crashed (bug in beman-tidy) -> fail
-          if [ $exit_code -eq 2 ]; then
+          if [ "${exit_code}" -eq 2 ]; then
             echo "::error::beman-tidy crashed on beman.${{ matrix.repo }} (exit code 2)"
             exit 1
           fi

--- a/tests/ci/test_detect_beman_tidy_mode.py
+++ b/tests/ci/test_detect_beman_tidy_mode.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / ".github" / "scripts"))
+
+from detect_beman_tidy_mode import detect_mode, has_beman_tidy_hook, uses_require_all
+
+
+def test__no_precommit__default_mode(tmp_path: Path):
+    assert detect_mode(tmp_path) == "default"
+
+
+def test__precommit_without_beman_tidy__default_mode(tmp_path: Path):
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n  - repo: local\n    hooks:\n      - id: trailing-whitespace\n"
+    )
+    assert detect_mode(tmp_path) == "default"
+
+
+def test__beman_tidy_without_require_all__default_mode(tmp_path: Path):
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n"
+        "  - repo: https://github.com/bemanproject/beman-tidy\n"
+        "    hooks:\n"
+        "      - id: beman-tidy\n"
+        "        args: [\".\", \"--verbose\"]\n"
+    )
+    assert detect_mode(tmp_path) == "default"
+
+
+def test__beman_tidy_with_require_all__require_all_mode(tmp_path: Path):
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n"
+        "  - repo: https://github.com/bemanproject/beman-tidy\n"
+        "    hooks:\n"
+        "      - id: beman-tidy\n"
+        "        args: [\".\", \"--verbose\", \"--require-all\"]\n"
+    )
+    assert detect_mode(tmp_path) == "require-all"
+
+
+def test__helpers():
+    cfg = "hooks:\n  - id: beman-tidy\n    args: [\"--require-all\"]\n"
+    assert has_beman_tidy_hook(cfg) is True
+    assert uses_require_all(cfg) is True
+    assert uses_require_all("hooks:\n  - id: other\n") is False


### PR DESCRIPTION
## Summary
Improves [Run on all Beman libraries](https://github.com/bemanproject/beman-tidy/actions/runs/29292365084) to mirror each library's pre-commit configuration:

- **`--require-all`** when `.pre-commit-config.yaml` configures the `beman-tidy` hook with `--require-all`
- **default mode** when the repo has no `beman-tidy` hook, or the hook runs without `--require-all`

## Changes
- Add `.github/scripts/detect_beman_tidy_mode.py`
- Update `run-on-all-libraries.yml` to pick mode per matrix repo
- Add unit tests in `tests/ci/`

## Test plan
- [x] `uv run pytest tests/ci/test_detect_beman_tidy_mode.py`
- [ ] Manual `workflow_dispatch` on run-on-all-libraries

Depends on: nothing
Blocks: PR2 (#TBD)