### PR TITLE
ci: open library issues when run-on-all beman-tidy checks fail

### DIFF
--- a/.github/scripts/create_library_beman_tidy_issue.py
+++ b/.github/scripts/create_library_beman_tidy_issue.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Open or update a beman-tidy failure issue in a Beman library repository."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ISSUE_TITLE = "[beman-tidy] Beman Standard check failure"
+EXTRA_ASSIGNEES = ("neatudarius",)
+ORG = "bemanproject"
+LOG_TRUNCATE_BYTES = 12000
+
+
+def _extract_users_from_line(line: str) -> list[str]:
+    users: list[str] = []
+    for token in line.split():
+        if not token.startswith("@"):
+            continue
+        if "/" in token:
+            continue
+        users.append(token[1:])
+    return users
+
+
+def parse_codeowners(repo_path: Path) -> list[str]:
+    codeowners = repo_path / ".github" / "CODEOWNERS"
+    if not codeowners.is_file():
+        return []
+
+    users: list[str] = []
+    seen: set[str] = set()
+    for raw_line in codeowners.read_text(encoding="utf-8", errors="ignore").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        for user in _extract_users_from_line(line):
+            if user not in seen:
+                seen.add(user)
+                users.append(user)
+    return users
+
+
+def gh(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["gh", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def find_open_issue(repo: str) -> int | None:
+    result = gh(
+        "issue",
+        "list",
+        "--repo",
+        f"{ORG}/{repo}",
+        "--state",
+        "open",
+        "--search",
+        ISSUE_TITLE,
+        "--limit",
+        "1",
+        "--json",
+        "number",
+    )
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+        return None
+
+    issues = json.loads(result.stdout or "[]")
+    if not issues:
+        return None
+    return int(issues[0]["number"])
+
+
+def build_body(
+    repo: str,
+    mode: str,
+    tidy_version: str,
+    run_url: str,
+    tidy_log: str,
+    assignees: list[str],
+) -> str:
+    mentions = " ".join(f"@{user}" for user in assignees)
+    log_excerpt = tidy_log[-LOG_TRUNCATE_BYTES:] if len(tidy_log) > LOG_TRUNCATE_BYTES else tidy_log
+
+    return f"""## beman-tidy check failure
+
+Până acum toate check-urile treceau în modul **`{mode}`** (conform configurației pre-commit din acest repo). Acum nu mai trec după ultima rulare `beman-tidy` din workflow-ul [Run on all Beman libraries]({run_url}).
+
+| Field | Value |
+|-------|-------|
+| Library | `beman.{repo}` |
+| Mode | `{mode}` |
+| beman-tidy | `{tidy_version}` |
+| Workflow run | {run_url} |
+
+### Output (truncated)
+
+```
+{log_excerpt}
+```
+
+### Owners
+
+{mentions}
+
+Please investigate which newly implemented or newly enforced checks are failing and update the repository accordingly.
+"""
+
+
+def create_or_update_issue(
+    repo: str,
+    mode: str,
+    tidy_version: str,
+    run_url: str,
+    tidy_log: str,
+    repo_path: Path,
+) -> int:
+    assignees = list(
+        dict.fromkeys([*parse_codeowners(repo_path), *EXTRA_ASSIGNEES])
+    )
+    body = build_body(repo, mode, tidy_version, run_url, tidy_log, assignees)
+    target = f"{ORG}/{repo}"
+
+    existing = find_open_issue(repo)
+    if existing is not None:
+        comment = gh("issue", "comment", "--repo", target, str(existing), "--body", body)
+        if comment.returncode != 0:
+            print(comment.stderr, file=sys.stderr)
+            return 1
+        print(f"Updated existing issue #{existing} in {target}")
+        return 0
+
+    create_args = [
+        "issue",
+        "create",
+        "--repo",
+        target,
+        "--title",
+        ISSUE_TITLE,
+        "--body",
+        body,
+    ]
+    for assignee in assignees:
+        create_args.extend(["--assignee", assignee])
+
+    created = gh(*create_args)
+    if created.returncode != 0:
+        print(created.stderr, file=sys.stderr)
+        return 1
+
+    print(created.stdout.strip())
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="Repository short name, e.g. optional")
+    parser.add_argument("--mode", required=True, choices=("default", "require-all"))
+    parser.add_argument("--log", required=True, type=Path, help="beman-tidy log file")
+    parser.add_argument("--run-url", required=True)
+    parser.add_argument("--tidy-version", default="unknown")
+    parser.add_argument(
+        "--repo-path",
+        type=Path,
+        help="Path to cloned repository (defaults to ./<repo>)",
+    )
+    args = parser.parse_args()
+
+    if not os.environ.get("GH_TOKEN"):
+        print("GH_TOKEN is required to create issues", file=sys.stderr)
+        return 1
+
+    repo_path = args.repo_path or Path(args.repo)
+    tidy_log = args.log.read_text(encoding="utf-8", errors="replace")
+    return create_or_update_issue(
+        args.repo,
+        args.mode,
+        args.tidy_version,
+        args.run_url,
+        tidy_log,
+        repo_path,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/scripts/create_library_beman_tidy_issue.py
+++ b/.github/scripts/create_library_beman_tidy_issue.py
@@ -93,7 +93,7 @@ def build_body(
 
     return f"""## beman-tidy check failure
 
-Până acum toate check-urile treceau în modul **`{mode}`** (conform configurației pre-commit din acest repo). Acum nu mai trec după ultima rulare `beman-tidy` din workflow-ul [Run on all Beman libraries]({run_url}).
+This repository previously passed beman-tidy checks in **`{mode}`** mode (per its pre-commit configuration). The latest [Run on all Beman libraries]({run_url}) workflow run now reports failures.
 
 | Field | Value |
 |-------|-------|

--- a/.github/scripts/detect_beman_tidy_mode.py
+++ b/.github/scripts/detect_beman_tidy_mode.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+"""Detect how beman-tidy should run for a Beman library repository."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from pathlib import Path
+
+_BEMAN_TIDY_HOOK_RE = re.compile(r"id:\s*beman-tidy\b")
+_REQUIRE_ALL_RE = re.compile(r"--require-all\b")
+
+
+def has_beman_tidy_hook(content: str) -> bool:
+    return _BEMAN_TIDY_HOOK_RE.search(content) is not None
+
+
+def uses_require_all(content: str) -> bool:
+    return has_beman_tidy_hook(content) and _REQUIRE_ALL_RE.search(content) is not None
+
+
+def detect_mode(repo_path: Path) -> str:
+    """
+    Return the beman-tidy invocation mode for a library repo.
+
+    - ``require-all``: pre-commit configures the beman-tidy hook with ``--require-all``.
+    - ``default``: no beman-tidy hook, or hook without ``--require-all``.
+    """
+    precommit = repo_path / ".pre-commit-config.yaml"
+    if not precommit.is_file():
+        return "default"
+
+    content = precommit.read_text(encoding="utf-8", errors="ignore")
+    if not has_beman_tidy_hook(content):
+        return "default"
+    if uses_require_all(content):
+        return "require-all"
+    return "default"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("repo_path", type=Path, help="Path to cloned library repository")
+    args = parser.parse_args()
+    print(detect_mode(args.repo_path))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/run-on-all-libraries.yml
+++ b/.github/workflows/run-on-all-libraries.yml
@@ -80,12 +80,23 @@ jobs:
 
       - name: Run beman-tidy on beman.${{ matrix.repo }}
         run: |
-          beman-tidy --verbose ${{ matrix.repo }}/
+          MODE=$(python3 .github/scripts/detect_beman_tidy_mode.py "${{ matrix.repo }}")
+          echo "Using beman-tidy mode: ${MODE} for beman.${{ matrix.repo }}"
+
+          ARGS=(--verbose)
+          if [ "${MODE}" = "require-all" ]; then
+            ARGS+=(--require-all)
+          fi
+
+          set +e
+          beman-tidy "${ARGS[@]}" "${{ matrix.repo }}/"
           exit_code=$?
+          set -e
+
           # Exit code 0: all checks passed
           # Exit code 1: violations found (acceptable - libraries may have open violations)
           # Exit code 2: beman-tidy crashed (bug in beman-tidy) -> fail
-          if [ $exit_code -eq 2 ]; then
+          if [ "${exit_code}" -eq 2 ]; then
             echo "::error::beman-tidy crashed on beman.${{ matrix.repo }} (exit code 2)"
             exit 1
           fi

--- a/.github/workflows/run-on-all-libraries.yml
+++ b/.github/workflows/run-on-all-libraries.yml
@@ -55,6 +55,9 @@ jobs:
     name: beman.${{ matrix.repo }}
     needs: parse-libraries
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
     strategy:
       fail-fast: false
       matrix:
@@ -79,6 +82,8 @@ jobs:
           git clone --depth=1 https://github.com/bemanproject/${{ matrix.repo }}.git
 
       - name: Run beman-tidy on beman.${{ matrix.repo }}
+        env:
+          GH_TOKEN: ${{ secrets.BEMAN_AUTOMATION_TOKEN }}
         run: |
           MODE=$(python3 .github/scripts/detect_beman_tidy_mode.py "${{ matrix.repo }}")
           echo "Using beman-tidy mode: ${MODE} for beman.${{ matrix.repo }}"
@@ -88,17 +93,30 @@ jobs:
             ARGS+=(--require-all)
           fi
 
+          LOG_FILE="${{ matrix.repo }}-tidy.log"
           set +e
-          beman-tidy "${ARGS[@]}" "${{ matrix.repo }}/"
+          beman-tidy "${ARGS[@]}" "${{ matrix.repo }}/" 2>&1 | tee "${LOG_FILE}"
           exit_code=$?
           set -e
 
+          TIDY_VERSION=$(beman-tidy --version 2>/dev/null || echo unknown)
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
           # Exit code 0: all checks passed
-          # Exit code 1: violations found (acceptable - libraries may have open violations)
+          # Exit code 1: violations found -> open issue in library repo
           # Exit code 2: beman-tidy crashed (bug in beman-tidy) -> fail
           if [ "${exit_code}" -eq 2 ]; then
             echo "::error::beman-tidy crashed on beman.${{ matrix.repo }} (exit code 2)"
             exit 1
+          fi
+          if [ "${exit_code}" -eq 1 ]; then
+            python3 .github/scripts/create_library_beman_tidy_issue.py \
+              --repo "${{ matrix.repo }}" \
+              --mode "${MODE}" \
+              --log "${LOG_FILE}" \
+              --run-url "${RUN_URL}" \
+              --tidy-version "${TIDY_VERSION}" \
+              --repo-path "${{ matrix.repo }}"
           fi
           exit 0
 

--- a/tests/ci/test_create_library_beman_tidy_issue.py
+++ b/tests/ci/test_create_library_beman_tidy_issue.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / ".github" / "scripts"))
+
+from create_library_beman_tidy_issue import (  # noqa: E402
+    build_body,
+    parse_codeowners,
+)
+
+
+def test__parse_codeowners__extracts_users(tmp_path: Path):
+    github_dir = tmp_path / ".github"
+    github_dir.mkdir()
+    (github_dir / "CODEOWNERS").write_text(
+        "# comment\n* @alice @bemanproject/team @bob\n"
+    )
+    assert parse_codeowners(tmp_path) == ["alice", "bob"]
+
+
+def test__parse_codeowners__missing_file(tmp_path: Path):
+    assert parse_codeowners(tmp_path) == []
+
+
+def test__build_body__mentions_assignees():
+    body = build_body(
+        repo="optional",
+        mode="require-all",
+        tidy_version="beman-tidy 0.5.2",
+        run_url="https://example.com/run/1",
+        tidy_log="check failed",
+        assignees=["steve-downey", "neatudarius"],
+    )
+    assert "require-all" in body
+    assert "@steve-downey" in body
+    assert "@neatudarius" in body
+    assert "Până acum toate check-urile" in body

--- a/tests/ci/test_create_library_beman_tidy_issue.py
+++ b/tests/ci/test_create_library_beman_tidy_issue.py
@@ -37,4 +37,4 @@ def test__build_body__mentions_assignees():
     assert "require-all" in body
     assert "@steve-downey" in body
     assert "@neatudarius" in body
-    assert "Până acum toate check-urile" in body
+    assert "previously passed beman-tidy checks" in body

--- a/tests/ci/test_detect_beman_tidy_mode.py
+++ b/tests/ci/test_detect_beman_tidy_mode.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / ".github" / "scripts"))
+
+from detect_beman_tidy_mode import detect_mode, has_beman_tidy_hook, uses_require_all
+
+
+def test__no_precommit__default_mode(tmp_path: Path):
+    assert detect_mode(tmp_path) == "default"
+
+
+def test__precommit_without_beman_tidy__default_mode(tmp_path: Path):
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n  - repo: local\n    hooks:\n      - id: trailing-whitespace\n"
+    )
+    assert detect_mode(tmp_path) == "default"
+
+
+def test__beman_tidy_without_require_all__default_mode(tmp_path: Path):
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n"
+        "  - repo: https://github.com/bemanproject/beman-tidy\n"
+        "    hooks:\n"
+        "      - id: beman-tidy\n"
+        "        args: [\".\", \"--verbose\"]\n"
+    )
+    assert detect_mode(tmp_path) == "default"
+
+
+def test__beman_tidy_with_require_all__require_all_mode(tmp_path: Path):
+    (tmp_path / ".pre-commit-config.yaml").write_text(
+        "repos:\n"
+        "  - repo: https://github.com/bemanproject/beman-tidy\n"
+        "    hooks:\n"
+        "      - id: beman-tidy\n"
+        "        args: [\".\", \"--verbose\", \"--require-all\"]\n"
+    )
+    assert detect_mode(tmp_path) == "require-all"
+
+
+def test__helpers():
+    cfg = "hooks:\n  - id: beman-tidy\n    args: [\"--require-all\"]\n"
+    assert has_beman_tidy_hook(cfg) is True
+    assert uses_require_all(cfg) is True
+    assert uses_require_all("hooks:\n  - id: other\n") is False


### PR DESCRIPTION
## Summary
Stacked on #349. When `beman-tidy` reports check failures for a library in **Run on all Beman libraries**, automatically open (or update) an issue in that library's repo.

Assignees: all users from `.github/CODEOWNERS` + `@neatudarius`.

Issue message explains that checks previously passed in the library's configured mode (`default` or `require-all`) but now fail after the latest `beman-tidy` run.

## Changes (on top of #349)
- Add `.github/scripts/create_library_beman_tidy_issue.py`
- On exit code 1, create/update `[beman-tidy] Beman Standard check failure` issue in `bemanproject/<repo>`
- Unit tests in `tests/ci/`

## Setup required
Cross-repo issue creation needs org secret **`BEMAN_AUTOMATION_TOKEN`** (PAT with `issues:write` on `bemanproject/*`).

## Test plan
- [x] `uv run pytest tests/ci/`
- [ ] `workflow_dispatch` after #349 merges + token configured

**Merge order:** #349 first, then rebase this PR onto `main` before merge.