### PR TITLE
Potential fix for code scanning alert no. 10: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/run-on-all-libraries.yml
+++ b/.github/workflows/run-on-all-libraries.yml
@@ -2,6 +2,9 @@
 
 name: Run on all Beman libraries
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 6 * * 0' # Weekly on Sunday 09:00 EEST


### PR DESCRIPTION
Potential fix for [https://github.com/bemanproject/beman-tidy/security/code-scanning/10](https://github.com/bemanproject/beman-tidy/security/code-scanning/10)

Add an explicit top-level `permissions` block in `.github/workflows/run-on-all-libraries.yml` so all jobs inherit least-privilege defaults.

Best single fix without changing functionality:
- Add at workflow root (after `name` and before `on`):
  - `contents: read` (needed by `actions/checkout` and general repo reads)
- Do not over-grant write scopes unless required by this workflow file. If the called reusable workflow needs additional permissions, that workflow can declare them, or they can be added later explicitly as needed.

This keeps current behavior while ensuring the workflow no longer depends on potentially broad repository/org defaults.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
