### PR TITLE
ci: fix CodeQL c-cpp autobuild failure

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,10 +4,8 @@
 # You may wish to alter this file to override the set of languages analyzed,
 # or to provide custom queries or build logic.
 #
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
+# beman-tidy is a Python tool. C/C++ files under tests/ are fixture data for
+# check validation, not compiled project code, so c-cpp is excluded from CodeQL.
 #
 name: "CodeQL Advanced"
 
@@ -45,8 +43,6 @@ jobs:
         include:
         - language: actions
           build-mode: none
-        - language: c-cpp
-          build-mode: autobuild
         - language: python
           build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
@@ -79,23 +75,6 @@ jobs:
 
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
-
-    # If the analyze step fails for one of the languages you are analyzing with
-    # "We were unable to automatically build your code", modify the matrix above
-    # to set the build mode to "manual" for that language. Then modify this step
-    # to build your code.
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-    - name: Run manual build steps
-      if: matrix.build-mode == 'manual'
-      shell: bash
-      run: |
-        echo 'If you are using a "manual" build mode for one or more of the' \
-          'languages you are analyzing, replace this with the commands to build' \
-          'your code, for example:'
-        echo '  make bootstrap'
-        echo '  make release'
-        exit 1
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
## Summary

Fixes the failing `CodeQL Advanced / Analyze (c-cpp)` check introduced in #340.

The job fails because CodeQL autobuild cannot find a C++ build target in beman-tidy ([example run](https://github.com/bemanproject/beman-tidy/actions/runs/29435741446/job/87421820252)). beman-tidy is a **Python** tool; the `.cpp`/`.hpp` files in the repo are **test fixture data** for Beman Standard checks, not compiled project source.

This PR removes `c-cpp` from the CodeQL matrix and keeps scanning for `actions` and `python`.

## Test plan

- [ ] `CodeQL Advanced / Analyze (actions)` passes
- [ ] `CodeQL Advanced / Analyze (python)` passes
- [ ] `Analyze (c-cpp)` job no longer runs
- [ ] Other CI checks unaffected


Made with [Cursor](https://cursor.com)