### PR TITLE
ci: fix CodeQL workflow permissions alerts

### DIFF
--- a/.github/workflows/beman-tidy.yml
+++ b/.github/workflows/beman-tidy.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '0 6 * * *' # 09:00AM EEST
 
+permissions:
+  contents: read
+
 jobs:
   run_linter:
     name: Run Linter
@@ -74,4 +77,5 @@ jobs:
   create-issue-when-fault:
     needs: [run_linter, run_tests, build_and_install]
     if: failure() && (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    permissions: {}
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ on:
     types:
       - published
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build Distributions

--- a/.github/workflows/run-on-all-libraries.yml
+++ b/.github/workflows/run-on-all-libraries.yml
@@ -8,6 +8,8 @@ on:
   workflow_call:
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   parse-libraries:
     name: Parse Beman library list
@@ -55,6 +57,8 @@ jobs:
     name: beman.${{ matrix.repo }}
     needs: parse-libraries
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -94,4 +98,5 @@ jobs:
   create-issue-when-fault:
     needs: [run-beman-tidy]
     if: failure() && (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    permissions: {}
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0

--- a/.github/workflows/run-on-exemplar.yml
+++ b/.github/workflows/run-on-exemplar.yml
@@ -12,6 +12,9 @@ on:
   schedule:
     - cron: '0 6 * * *' # 09:00AM EEST
 
+permissions:
+  contents: read
+
 jobs:
   run_on_exemplar:
     name: Run on beman.exemplar
@@ -48,4 +51,5 @@ jobs:
   create-issue-when-fault:
     needs: [run_on_exemplar]
     if: failure() && (github.event_name == 'workflow_call' || github.event_name == 'workflow_dispatch' || github.event_name == 'schedule')
+    permissions: {}
     uses: bemanproject/infra-workflows/.github/workflows/reusable-beman-create-issue-when-fault.yml@1.1.0


### PR DESCRIPTION
## Summary

Resolves all 10 open [code scanning alerts](https://github.com/bemanproject/beman-tidy/security/code-scanning) (`actions/missing-workflow-permissions`) by adding explicit `GITHUB_TOKEN` permission scopes:

| Workflow | Change |
|----------|--------|
| `beman-tidy.yml` | `permissions: contents: read` at workflow level; `permissions: {}` on reusable `create-issue-when-fault` job |
| `run-on-exemplar.yml` | same pattern |
| `run-on-all-libraries.yml` | `permissions: {}` default; `contents: read` on `run-beman-tidy`; `permissions: {}` on `create-issue-when-fault` |
| `publish.yml` | `permissions: contents: read` at workflow level (`publish` job keeps `id-token: write`) |

Follows the same least-privilege pattern used in other Beman repos (e.g. `beman.optional`).

Rebased on `main` (includes #354 CodeQL c-cpp fix).

## Test plan

- [ ] All existing CI jobs still pass
- [ ] CodeQL `Analyze (actions)` no longer reports `missing-workflow-permissions` on these workflows
- [ ] Open code scanning alerts auto-close after merge