### PR TITLE
[beman-tidy] Implement cmake.skip_examples

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/cmake.py
+++ b/beman_tidy/lib/checks/beman_standard/cmake.py
@@ -337,7 +337,53 @@ class CMakeSkipTestsCheck(CMakeBaseCheck):
         )
         return False
 
-# TODO cmake.skip_examples
+
+@register_beman_standard_check("cmake.skip_examples")
+class CMakeSkipExamplesCheck(CMakeBaseCheck):
+    _SUBDIR_NAME = "examples"
+    _STANDARD_ANCHOR = "cmakeskip_examples"
+
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def _build_option_name(self):
+        return f"BEMAN_{self.short_name.upper()}_BUILD_EXAMPLES"
+
+    def check(self):
+        content = self.read()
+        option_name = self._build_option_name()
+
+        if not cmake_build_skip_subdir_option_pattern(option_name).search(content):
+            self.log(
+                f"Missing or invalid CMake option '{option_name}' with default "
+                f"'${{PROJECT_IS_TOP_LEVEL}}'. "
+                "Please update the CMakeLists.txt file according to the Beman Standard. "
+                f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#{self._STANDARD_ANCHOR} for more information."
+            )
+            return False
+
+        ast_tree = list(self.get_cmake_parse_tree())
+        if cmake_has_unguarded_subdirectory(ast_tree, self._SUBDIR_NAME, option_name):
+            self.log(
+                f"Examples are not guarded by 'if({option_name})' before "
+                "'add_subdirectory(examples...)'. "
+                "Please update the CMakeLists.txt file according to the Beman Standard. "
+                f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#{self._STANDARD_ANCHOR} for more information."
+            )
+            return False
+
+        return True
+
+    def fix(self):
+        option_name = self._build_option_name()
+        self.log(
+            "Please update the CMakeLists.txt file so that examples are controlled by "
+            f"'option({option_name} ... ${{PROJECT_IS_TOP_LEVEL}})' "
+            f"and guarded by 'if({option_name})' before "
+            "'add_subdirectory(examples...)'. "
+            f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#{self._STANDARD_ANCHOR} for more information."
+        )
+        return False
 
 
 # TODO cmake.avoid_passthroughs

--- a/beman_tidy/lib/checks/beman_standard/cmake.py
+++ b/beman_tidy/lib/checks/beman_standard/cmake.py
@@ -7,6 +7,11 @@ from collections.abc import Iterable
 import cmake_parser
 from cmake_parser.ast import AstNode, Command
 
+from beman_tidy.lib.utils.cmake import (
+    cmake_build_skip_subdir_option_pattern,
+    cmake_has_unguarded_subdirectory,
+)
+
 from ..system.registry import register_beman_standard_check
 from ..base.file_base_check import FileBaseCheck
 
@@ -285,8 +290,52 @@ class CMakeTargetNamesCheck(CMakeBaseCheck):
 # TODO cmake.passive_targets
 
 
-# TODO cmake.skip_tests
+@register_beman_standard_check("cmake.skip_tests")
+class CMakeSkipTestsCheck(CMakeBaseCheck):
+    _SUBDIR_NAME = "tests"
+    _STANDARD_ANCHOR = "cmakeskip_tests"
 
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def _build_option_name(self):
+        return f"BEMAN_{self.short_name.upper()}_BUILD_TESTS"
+
+    def check(self):
+        content = self.read()
+        option_name = self._build_option_name()
+
+        if not cmake_build_skip_subdir_option_pattern(option_name).search(content):
+            self.log(
+                f"Missing or invalid CMake option '{option_name}' with default "
+                f"'${{PROJECT_IS_TOP_LEVEL}}'. "
+                "Please update the CMakeLists.txt file according to the Beman Standard. "
+                f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#{self._STANDARD_ANCHOR} for more information."
+            )
+            return False
+
+        ast_tree = list(self.get_cmake_parse_tree())
+        if cmake_has_unguarded_subdirectory(ast_tree, self._SUBDIR_NAME, option_name):
+            self.log(
+                f"Tests are not guarded by 'if({option_name})' before "
+                "'add_subdirectory(tests...)'. "
+                "Please update the CMakeLists.txt file according to the Beman Standard. "
+                f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#{self._STANDARD_ANCHOR} for more information."
+            )
+            return False
+
+        return True
+
+    def fix(self):
+        option_name = self._build_option_name()
+        self.log(
+            "Please update the CMakeLists.txt file so that tests are controlled by "
+            f"'option({option_name} ... ${{PROJECT_IS_TOP_LEVEL}})' "
+            f"and guarded by 'if({option_name})' before "
+            "'add_subdirectory(tests...)'. "
+            f"See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#{self._STANDARD_ANCHOR} for more information."
+        )
+        return False
 
 # TODO cmake.skip_examples
 

--- a/beman_tidy/lib/utils/cmake.py
+++ b/beman_tidy/lib/utils/cmake.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import re
+
+from cmake_parser.ast import Command, If
+
+
+def cmake_is_subdirectory(command, subdir_name):
+    if getattr(command, "identifier", None) != "add_subdirectory" or not command.args:
+        return False
+    arg = command.args[0].value.strip('"')
+    return arg == subdir_name or arg.startswith(f"{subdir_name}/")
+
+
+def cmake_has_unguarded_subdirectory(nodes, subdir_name, option_name, inside_guard=False):
+    for item in nodes:
+        if isinstance(item, Command):
+            if cmake_is_subdirectory(item, subdir_name) and not inside_guard:
+                return True
+        elif isinstance(item, If):
+            guard = bool(item.args and item.args[0].value == option_name)
+            if cmake_has_unguarded_subdirectory(
+                item.if_true or [], subdir_name, option_name, inside_guard or guard
+            ):
+                return True
+            if cmake_has_unguarded_subdirectory(
+                item.if_false or [], subdir_name, option_name, inside_guard
+            ):
+                return True
+    return False
+
+
+def cmake_build_skip_subdir_option_pattern(option_name):
+    return re.compile(
+        r"option\s*\(\s*"
+        + re.escape(option_name)
+        + r'\s*"(?:[^"\\]|\\.)*"\s*'
+        + re.escape("${PROJECT_IS_TOP_LEVEL}")
+        + r"\s*\)",
+    )

--- a/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_examples-v1.txt
+++ b/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_examples-v1.txt
@@ -1,0 +1,27 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.30...4.3)
+
+project(
+    beman.exemplar
+    DESCRIPTION "A Beman Library Exemplar"
+    LANGUAGES CXX
+    VERSION 0.1.0
+)
+
+# [CMAKE.SKIP_TESTS]
+option(
+    BEMAN_EXEMPLAR_BUILD_TESTS
+    "Enable building tests and test infrastructure. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+add_library(beman.exemplar INTERFACE)
+add_library(beman::exemplar ALIAS beman.exemplar)
+
+if(BEMAN_EXEMPLAR_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests/beman/exemplar)
+endif()
+
+add_subdirectory(examples)

--- a/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_examples-v2.txt
+++ b/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_examples-v2.txt
@@ -1,0 +1,24 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.30...4.3)
+
+project(
+    beman.exemplar
+    DESCRIPTION "A Beman Library Exemplar"
+    LANGUAGES CXX
+    VERSION 0.1.0
+)
+
+# [CMAKE.SKIP_EXAMPLES]
+option(
+    BEMAN_EXEMPLAR_BUILD_EXAMPLES
+    "Enable building examples. Default: ON. Values: { ON, OFF }."
+    ON
+)
+
+add_library(beman.exemplar INTERFACE)
+add_library(beman::exemplar ALIAS beman.exemplar)
+
+if(BEMAN_EXEMPLAR_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_examples-v3.txt
+++ b/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_examples-v3.txt
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.30...4.3)
+
+project(
+    beman.exemplar
+    DESCRIPTION "A Beman Library Exemplar"
+    LANGUAGES CXX
+    VERSION 0.1.0
+)
+
+# [CMAKE.SKIP_EXAMPLES]
+option(
+    BEMAN_EXEMPLAR_BUILD_EXAMPLES
+    "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+add_library(beman.exemplar INTERFACE)
+add_library(beman::exemplar ALIAS beman.exemplar)
+
+add_subdirectory(examples)

--- a/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_examples-v4.txt
+++ b/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_examples-v4.txt
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.30...4.3)
+
+project(
+    beman.exemplar
+    DESCRIPTION "A Beman Library Exemplar"
+    LANGUAGES CXX
+    VERSION 0.1.0
+)
+
+option(
+    BEMAN_EXEMPLAR_BUILD_EXAMPLES
+    "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+add_library(beman.exemplar INTERFACE)
+add_library(beman::exemplar ALIAS beman.exemplar)
+
+if(BEMAN_EXEMPLAR_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+add_subdirectory(examples)

--- a/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_tests-v1.txt
+++ b/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_tests-v1.txt
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.30...4.3)
+
+project(
+    beman.exemplar # CMake Project Name, which is also the name of the top-level
+    # targets (e.g., library, executable, etc.).
+    DESCRIPTION "A Beman Library Exemplar"
+    LANGUAGES CXX
+    VERSION 0.1.0
+)
+
+# [CMAKE.SKIP_EXAMPLES]
+option(
+    BEMAN_EXEMPLAR_BUILD_EXAMPLES
+    "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+# for find of beman_install_library and configure_build_telemetry
+include(infra/cmake/beman-install-library.cmake)
+include(infra/cmake/BuildTelemetryConfig.cmake)
+
+add_library(beman.exemplar INTERFACE)
+add_library(beman::exemplar ALIAS beman.exemplar)
+
+target_sources(
+    beman.exemplar
+    PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+
+set_target_properties(
+    beman.exemplar
+    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
+)
+
+add_subdirectory(include/beman/exemplar)
+
+beman_install_library(beman.exemplar TARGETS beman.exemplar)
+configure_build_telemetry()
+
+if(BEMAN_EXEMPLAR_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests/beman/exemplar)
+endif()
+
+if(BEMAN_EXEMPLAR_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_tests-v2.txt
+++ b/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_tests-v2.txt
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.30...4.3)
+
+project(
+    beman.exemplar # CMake Project Name, which is also the name of the top-level
+    # targets (e.g., library, executable, etc.).
+    DESCRIPTION "A Beman Library Exemplar"
+    LANGUAGES CXX
+    VERSION 0.1.0
+)
+
+# [CMAKE.SKIP_TESTS]
+option(
+    BEMAN_EXEMPLAR_BUILD_TESTS
+    "Enable building tests and test infrastructure. Default: ON. Values: { ON, OFF }."
+    ON
+)
+
+# [CMAKE.SKIP_EXAMPLES]
+option(
+    BEMAN_EXEMPLAR_BUILD_EXAMPLES
+    "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+# for find of beman_install_library and configure_build_telemetry
+include(infra/cmake/beman-install-library.cmake)
+include(infra/cmake/BuildTelemetryConfig.cmake)
+
+add_library(beman.exemplar INTERFACE)
+add_library(beman::exemplar ALIAS beman.exemplar)
+
+target_sources(
+    beman.exemplar
+    PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+
+set_target_properties(
+    beman.exemplar
+    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
+)
+
+add_subdirectory(include/beman/exemplar)
+
+beman_install_library(beman.exemplar TARGETS beman.exemplar)
+configure_build_telemetry()
+
+if(BEMAN_EXEMPLAR_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests/beman/exemplar)
+endif()
+
+if(BEMAN_EXEMPLAR_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_tests-v3.txt
+++ b/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_tests-v3.txt
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.30...4.3)
+
+project(
+    beman.exemplar # CMake Project Name, which is also the name of the top-level
+    # targets (e.g., library, executable, etc.).
+    DESCRIPTION "A Beman Library Exemplar"
+    LANGUAGES CXX
+    VERSION 0.1.0
+)
+
+# [CMAKE.SKIP_TESTS]
+option(
+    BEMAN_EXEMPLAR_BUILD_TESTS
+    "Enable building tests and test infrastructure. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+# [CMAKE.SKIP_EXAMPLES]
+option(
+    BEMAN_EXEMPLAR_BUILD_EXAMPLES
+    "Enable building examples. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+# for find of beman_install_library and configure_build_telemetry
+include(infra/cmake/beman-install-library.cmake)
+include(infra/cmake/BuildTelemetryConfig.cmake)
+
+add_library(beman.exemplar INTERFACE)
+add_library(beman::exemplar ALIAS beman.exemplar)
+
+target_sources(
+    beman.exemplar
+    PUBLIC FILE_SET HEADERS BASE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/include"
+)
+
+set_target_properties(
+    beman.exemplar
+    PROPERTIES VERIFY_INTERFACE_HEADER_SETS ${PROJECT_IS_TOP_LEVEL}
+)
+
+add_subdirectory(include/beman/exemplar)
+
+beman_install_library(beman.exemplar TARGETS beman.exemplar)
+configure_build_telemetry()
+
+enable_testing()
+add_subdirectory(tests/beman/exemplar)
+
+if(BEMAN_EXEMPLAR_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()

--- a/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_tests-v4.txt
+++ b/tests/lib/checks/beman_standard/cmake/data/invalid/invalid-skip_tests-v4.txt
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+cmake_minimum_required(VERSION 3.30...4.3)
+
+project(
+    beman.exemplar
+    DESCRIPTION "A Beman Library Exemplar"
+    LANGUAGES CXX
+    VERSION 0.1.0
+)
+
+option(
+    BEMAN_EXEMPLAR_BUILD_TESTS
+    "Enable building tests and test infrastructure. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+    ${PROJECT_IS_TOP_LEVEL}
+)
+
+add_library(beman.exemplar INTERFACE)
+add_library(beman::exemplar ALIAS beman.exemplar)
+
+if(BEMAN_EXEMPLAR_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(tests/beman/exemplar)
+endif()
+
+add_subdirectory(tests/beman/exemplar)

--- a/tests/lib/checks/beman_standard/cmake/test_cmake.py
+++ b/tests/lib/checks/beman_standard/cmake/test_cmake.py
@@ -15,6 +15,7 @@ from beman_tidy.lib.checks.beman_standard.cmake import (
     CMakeLibraryAliasCheck,
     CMakeTargetNamesCheck,
     CMakeSkipTestsCheck,
+    CMakeSkipExamplesCheck,
 )
 
 test_data_prefix = "tests/lib/checks/beman_standard/cmake/data"
@@ -262,6 +263,52 @@ def test__cmake_skip_tests__invalid(repo_info, beman_standard_check_config):
 
 @pytest.mark.skip(reason="not implemented")
 def test__cmake_skip_tests__fix_inplace(repo_info, beman_standard_check_config):
+    """
+    Test that the fix method corrects an invalid CMakeLists.txt file.
+    Note: Skipping this test as it is not implemented.
+    """
+    pass
+
+
+def test__cmake_skip_examples__valid(repo_info, beman_standard_check_config):
+    """
+    Test that a valid CMakeLists.txt file passes the cmake.skip_examples check.
+    """
+    valid_cmake_paths = [
+        Path(f"{valid_prefix}/CMakeLists-v1.txt"),
+    ]
+
+    run_check_for_each_path(
+        True,
+        valid_cmake_paths,
+        CMakeSkipExamplesCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
+
+
+def test__cmake_skip_examples__invalid(repo_info, beman_standard_check_config):
+    """
+    Test that an invalid CMakeLists.txt file fails the cmake.skip_examples check.
+    """
+    invalid_cmake_paths = [
+        Path(f"{invalid_prefix}/invalid-skip_examples-v1.txt"),
+        Path(f"{invalid_prefix}/invalid-skip_examples-v2.txt"),
+        Path(f"{invalid_prefix}/invalid-skip_examples-v3.txt"),
+        Path(f"{invalid_prefix}/invalid-skip_examples-v4.txt"),
+    ]
+
+    run_check_for_each_path(
+        False,
+        invalid_cmake_paths,
+        CMakeSkipExamplesCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
+
+
+@pytest.mark.skip(reason="not implemented")
+def test__cmake_skip_examples__fix_inplace(repo_info, beman_standard_check_config):
     """
     Test that the fix method corrects an invalid CMakeLists.txt file.
     Note: Skipping this test as it is not implemented.

--- a/tests/lib/checks/beman_standard/cmake/test_cmake.py
+++ b/tests/lib/checks/beman_standard/cmake/test_cmake.py
@@ -14,6 +14,7 @@ from beman_tidy.lib.checks.beman_standard.cmake import (
     CMakeLibraryNameCheck,
     CMakeLibraryAliasCheck,
     CMakeTargetNamesCheck,
+    CMakeSkipTestsCheck,
 )
 
 test_data_prefix = "tests/lib/checks/beman_standard/cmake/data"
@@ -210,6 +211,57 @@ def test__cmake_target_names__invalid(repo_info, beman_standard_check_config):
 
 @pytest.mark.skip(reason="not implemented")
 def test__cmake_target_names__fix_inplace(repo_info, beman_standard_check_config):
+    """
+    Test that the fix method corrects an invalid CMakeLists.txt file.
+    Note: Skipping this test as it is not implemented.
+    """
+    pass
+
+
+def test__cmake_skip_tests__valid(repo_info, beman_standard_check_config):
+    """
+    Test that a valid CMakeLists.txt file passes the cmake.skip_tests check.
+    """
+    valid_cmake_paths = [
+        # CMakeLists.txt from beman.exemplar
+        Path(f"{valid_prefix}/CMakeLists-v1.txt"),
+    ]
+
+    run_check_for_each_path(
+        True,
+        valid_cmake_paths,
+        CMakeSkipTestsCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
+
+
+def test__cmake_skip_tests__invalid(repo_info, beman_standard_check_config):
+    """
+    Test that an invalid CMakeLists.txt file fails the cmake.skip_tests check.
+    """
+    invalid_cmake_paths = [
+        # CMakeLists.txt missing BEMAN_EXEMPLAR_BUILD_TESTS option
+        Path(f"{invalid_prefix}/invalid-skip_tests-v1.txt"),
+        # CMakeLists.txt with wrong option default
+        Path(f"{invalid_prefix}/invalid-skip_tests-v2.txt"),
+        # CMakeLists.txt without if(BEMAN_EXEMPLAR_BUILD_TESTS) guard
+        Path(f"{invalid_prefix}/invalid-skip_tests-v3.txt"),
+        # CMakeLists.txt with guarded and unguarded add_subdirectory(tests...)
+        Path(f"{invalid_prefix}/invalid-skip_tests-v4.txt"),
+    ]
+
+    run_check_for_each_path(
+        False,
+        invalid_cmake_paths,
+        CMakeSkipTestsCheck,
+        repo_info,
+        beman_standard_check_config,
+    )
+
+
+@pytest.mark.skip(reason="not implemented")
+def test__cmake_skip_tests__fix_inplace(repo_info, beman_standard_check_config):
     """
     Test that the fix method corrects an invalid CMakeLists.txt file.
     Note: Skipping this test as it is not implemented.

--- a/tests/lib/utils/test_cmake.py
+++ b/tests/lib/utils/test_cmake.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import cmake_parser
+
+from beman_tidy.lib.utils.cmake import (
+    cmake_build_skip_subdir_option_pattern,
+    cmake_has_unguarded_subdirectory,
+    cmake_is_subdirectory,
+)
+
+
+def _parse_tree(cmake_source):
+    return list(cmake_parser.parser.parse_tree(cmake_source, skip_comments=True))
+
+
+def _command(identifier, arg):
+    tree = _parse_tree(f"{identifier}({arg})")
+    return tree[0]
+
+
+def test__cmake_is_subdirectory__matches_exact_and_nested():
+    assert cmake_is_subdirectory(_command("add_subdirectory", "tests"), "tests")
+    assert cmake_is_subdirectory(_command("add_subdirectory", "tests/beman/foo"), "tests")
+    assert cmake_is_subdirectory(_command("add_subdirectory", '"examples"'), "examples")
+
+
+def test__cmake_is_subdirectory__rejects_other_commands_and_paths():
+    assert not cmake_is_subdirectory(_command("add_subdirectory", "examples"), "tests")
+    assert not cmake_is_subdirectory(_command("include", "tests"), "tests")
+    assert not cmake_is_subdirectory(_command("add_subdirectory", ""), "tests")
+
+
+def test__cmake_has_unguarded_subdirectory__detects_unguarded_add_subdirectory():
+    tree = _parse_tree(
+        """
+        if(BEMAN_EXEMPLAR_BUILD_TESTS)
+            add_subdirectory(tests/beman/exemplar)
+        endif()
+        add_subdirectory(tests/beman/exemplar)
+        """
+    )
+    assert cmake_has_unguarded_subdirectory(tree, "tests", "BEMAN_EXEMPLAR_BUILD_TESTS")
+
+
+def test__cmake_has_unguarded_subdirectory__accepts_fully_guarded_subdirectory():
+    tree = _parse_tree(
+        """
+        if(BEMAN_EXEMPLAR_BUILD_TESTS)
+            add_subdirectory(tests/beman/exemplar)
+        endif()
+        """
+    )
+    assert not cmake_has_unguarded_subdirectory(tree, "tests", "BEMAN_EXEMPLAR_BUILD_TESTS")
+
+
+def test__cmake_has_unguarded_subdirectory__detects_missing_guard():
+    tree = _parse_tree("add_subdirectory(examples)")
+    assert cmake_has_unguarded_subdirectory(tree, "examples", "BEMAN_EXEMPLAR_BUILD_EXAMPLES")
+
+
+def test__cmake_build_skip_subdir_option_pattern__matches_project_is_top_level_default():
+    pattern = cmake_build_skip_subdir_option_pattern("BEMAN_EXEMPLAR_BUILD_TESTS")
+    cmake = """
+    option(
+        BEMAN_EXEMPLAR_BUILD_TESTS
+        "Enable building tests and test infrastructure. Default: ${PROJECT_IS_TOP_LEVEL}. Values: { ON, OFF }."
+        ${PROJECT_IS_TOP_LEVEL}
+    )
+    """
+    assert pattern.search(cmake)
+
+
+def test__cmake_build_skip_subdir_option_pattern__rejects_wrong_default():
+    pattern = cmake_build_skip_subdir_option_pattern("BEMAN_EXEMPLAR_BUILD_TESTS")
+    cmake = """
+    option(
+        BEMAN_EXEMPLAR_BUILD_TESTS
+        "Enable building tests and test infrastructure. Default: ON. Values: { ON, OFF }."
+        ON
+    )
+    """
+    assert not pattern.search(cmake)


### PR DESCRIPTION
Implements #72

Local tested - it already runs and passes for 20/22 libraries in org. Check linked PRs for fixing remaining libraries. 
This PR will be merged when all Beman library are green or their .beman-tidy.yml config disables this check.

Stacked on #346 (`implement/issue-73-cmake-skip-tests`). Review only the
skip_examples delta:

https://github.com/neatudarius/beman-tidy/compare/implement/issue-73-cmake-skip-tests...issue-72

After #346 merges, this branch will be rebased onto `main`.