### PR TITLE
[beman-tidy] Register release.version as offline skip check

### DIFF
--- a/beman_tidy/lib/checks/beman_standard/release.py
+++ b/beman_tidy/lib/checks/beman_standard/release.py
@@ -41,6 +41,21 @@ class ReleaseNotesCheck(BaseCheck):
         return True
 
 
+@register_beman_standard_check("release.version")
+class ReleaseVersionCheck(BaseCheck):
+    def __init__(self, repo_info, beman_standard_check_config):
+        super().__init__(repo_info, beman_standard_check_config)
+
+    def should_skip(self):
+        # Cannot actually implement release.version offline, thus skip it.
+        self.log(
+            "beman-tidy cannot actually check release.version. "
+            "Release versioning policy requires context that is not available to an offline tool. "
+            "See https://github.com/bemanproject/beman/blob/main/docs/beman_standard.md#releaseversion."
+        )
+        return True
+
+
 @register_beman_standard_check("release.godbolt_trunk_version")
 class ReleaseGodboltTrunkVersionCheck(ReadmeBaseCheck):
     def __init__(self, repo_info, beman_standard_check_config):

--- a/tests/lib/checks/beman_standard/release/test_release.py
+++ b/tests/lib/checks/beman_standard/release/test_release.py
@@ -13,6 +13,7 @@ from beman_tidy.lib.checks.beman_standard.release import (
     ReleaseGithubCheck,
     ReleaseGodboltTrunkVersionCheck,
     ReleaseNotesCheck,
+    ReleaseVersionCheck,
 )
 
 test_data_prefix = "tests/lib/checks/beman_standard/release/data"
@@ -32,6 +33,13 @@ def test__release_notes__is_always_skipped(repo_info, beman_standard_check_confi
     Test that release.notes is always skipped, as it cannot be implemented.
     """
     assert ReleaseNotesCheck(repo_info, beman_standard_check_config).should_skip()
+
+
+def test__release_version__is_always_skipped(repo_info, beman_standard_check_config):
+    """
+    Test that release.version is always skipped, as it cannot be implemented offline.
+    """
+    assert ReleaseVersionCheck(repo_info, beman_standard_check_config).should_skip()
 
 
 def test__release_godbolt_trunk_version__valid(repo_info, beman_standard_check_config):


### PR DESCRIPTION
Implements #356

`release.version` is registered but always skipped (like `release.notes`).
Versioning policy requires context unavailable to an offline v1 tool.