### PR TITLE
Honor .gitignore and accept gitignore syntax in ignored_paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,9 +184,11 @@ tests, build/install, and running `beman-tidy` on `bemanproject/exemplar`.
 
 The following configuration options may be used in a `.beman-tidy.yaml` file:
 
-- `ignored_paths` - A list of paths to be excluded from all checks.
+- `ignored_paths` - A list of patterns for paths to be excluded from all checks.
+  - Entries use [`.gitignore` pattern syntax](https://git-scm.com/docs/gitignore#_pattern_format): wildcards (`*`, `?`, `[abc]`), `**` for spanning directories, a leading `/` to anchor a pattern to the repository root, a trailing `/` to match directories only, and a leading `!` to re-include a path.
   - To ignore a specific file, provide its full path relative to the repository root.
   - To ignore a directory, provide the path to that directory. This will ignore the directory itself and all files and subdirectories within it. A trailing slash (`/`) is optional.
+  - A pattern without a `/` matches at any depth, so `detail` ignores every `detail` entry in the repository, while `/detail` only ignores the one in the root.
 
 - Example:
   ```yaml
@@ -196,7 +198,28 @@ The following configuration options may be used in a `.beman-tidy.yaml` file:
 
     # Ignores a directory and everything inside it
     - include/beman/optional/another_dir
+
+    # Ignores every generated header, wherever it is
+    - "**/generated/*.hpp"
+
+    # Checks one file anyway, even though the pattern above covers it
+    - "!include/beman/optional/generated/api.hpp"
   ```
+
+- `use_gitignore` - Whether the `.gitignore` files of the repository are honored. Defaults to `true`.
+  - Every `.gitignore` in the repository is applied, each relative to its own directory, exactly as git applies them. A `.gitignore` inside an ignored directory is not read.
+  - `README.md` and `LICENSE` are mandatory and are checked even if a `.gitignore` matches them. A warning is printed when that happens.
+  - As in git, a path below an ignored *directory* cannot be re-included: if a `.gitignore` has `generated/`, no `!generated/api.hpp` entry brings `api.hpp` back. The repository has to ignore `generated/*` instead.
+  - Set it to `false` to check paths that the repository does not track:
+
+  ```yaml
+  use_gitignore: false
+  ```
+
+- Ignore sources are consulted in this order, and the first pattern that matches decides:
+  1. `ignored_paths` from `.beman-tidy.yaml`
+  2. the `.gitignore` files of the repository, deepest directory first
+  3. beman-tidy's built-in ignores (`build/`, `.git/`, `__pycache__/`, IDE directories, ...)
 
 - `disabled_rules` - A list of rule names (or patterns) to be completely skipped during checks.
   - To disable a specific rule, provide its exact name (e.g., `readme.title`).
@@ -229,7 +252,9 @@ The following configuration options may be used in a `.beman-tidy.yaml` file:
 - Why do I see "not implemented" in the summary?
   - The check exists in the Beman Standard snapshot but does not yet have an implemented checker.
 - How do I ignore files/directories?
-  - Use `ignored_paths` in `.beman-tidy.yaml`.
+  - Use `ignored_paths` in `.beman-tidy.yaml`. Entries use `.gitignore` pattern syntax.
+- Why is a file in my repository not being checked at all?
+  - It is probably matched by your `.gitignore`, which beman-tidy honors by default. Set `use_gitignore: false` in `.beman-tidy.yaml` to check ignored files too, or re-include a single path with a `!` entry in `ignored_paths`.
 - How do I disable specific rules?
   - Use `disabled_rules` in `.beman-tidy.yaml`. You can specify exact rule names or glob patterns like `readme.*`.
 - How do I get more detail?

--- a/beman_tidy/lib/checks/base/directory_base_check.py
+++ b/beman_tidy/lib/checks/base/directory_base_check.py
@@ -52,7 +52,7 @@ class DirectoryBaseCheck(BaseCheck):
         """
         if super().should_skip():
             return True
-        return is_ignored(self.repo_info, self.relative_path)
+        return is_ignored(self.repo_info, self.relative_path, is_dir=True)
 
     @abstractmethod
     def check(self):

--- a/beman_tidy/lib/checks/base/file_base_check.py
+++ b/beman_tidy/lib/checks/base/file_base_check.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 from beman_tidy.lib.utils.string import normalize_path_for_display
 from .base_check import BaseCheck
-from ...utils.config import is_ignored, get_ignores
+from ...utils.config import is_ignored, get_ignore_matcher
 
 
 class FileBaseCheck(BaseCheck):
@@ -189,7 +189,7 @@ class BatchFileBaseCheck(BaseCheck):
         self._validate()
         assert self.file_path_generator is not None
 
-        ignores = get_ignores(self.repo_info)
+        ignores = get_ignore_matcher(self.repo_info)
 
         all_files = self.file_path_generator(self.repo_path, ignores=ignores)
         all_successful = True

--- a/beman_tidy/lib/utils/config.py
+++ b/beman_tidy/lib/utils/config.py
@@ -7,10 +7,13 @@ import yaml
 import logging
 
 from pathlib import Path
-from beman_tidy.lib.utils.file import get_repo_ignorable_subdirectories
+from beman_tidy.lib.utils import ignore
 from beman_tidy.lib.utils.logger_config import setup_logging
 
 setup_logging()
+
+# .gitignore is honored unless the repository configuration opts out.
+DEFAULT_USE_GITIGNORE = True
 
 def validate_config(config):
     """
@@ -45,6 +48,25 @@ def validate_config(config):
             return False
              
     if not _validate_disabled_rules(config):
+        return False
+
+    if not _validate_use_gitignore(config):
+        return False
+
+    return True
+
+
+def _validate_use_gitignore(config):
+    """
+    Validate the 'use_gitignore' configuration.
+    Returns True if valid, False otherwise.
+    """
+    use_gitignore = config.get("use_gitignore")
+    if use_gitignore is None:
+        return True
+
+    if not isinstance(use_gitignore, bool):
+        logging.error(f"Error: 'use_gitignore' in .beman-tidy.yaml must be a boolean, but got {type(use_gitignore).__name__}.")
         return False
 
     return True
@@ -160,31 +182,26 @@ def load_repo_config(repo_path, config_path=None):
     return merged_config
 
 
-def get_ignores(repo_info):
+def get_ignore_matcher(repo_info):
     """
-    Returns a combined list of default system ignores and user-configured ignores.
+    Returns the IgnoreMatcher for the repository, combining the built-in ignores,
+    the configured 'ignored_paths' and - unless 'use_gitignore' is false - the
+    .gitignore files of the repository.
     """
+    config = repo_info.get("config", {})
+    return ignore.get_ignore_matcher(
+        repo_info.get("top_level", "."),
+        config.get("ignored_paths") or [],
+        config.get("use_gitignore", DEFAULT_USE_GITIGNORE),
+    )
 
-    default_ignores = get_repo_ignorable_subdirectories()
-    user_ignores = repo_info.get("config", {}).get("ignored_paths") or []
-    return list(default_ignores) + user_ignores
 
-
-def is_ignored(repo_info, relative_path):
+def is_ignored(repo_info, relative_path, is_dir=None):
     """
     Check if a given path is ignored by the configuration.
     A path can be a file or a directory.
     If a directory is ignored, all its children are also ignored.
+
+    @param is_dir: Whether the path is a directory. Determined from disk when None.
     """
-    ignores = get_ignores(repo_info)
-    rel_path_str = relative_path.as_posix()
-    for ignore in ignores:
-        ignore_str = str(ignore).rstrip('/')
-
-        if rel_path_str == ignore_str:
-            return True
-        
-        if rel_path_str.startswith(ignore_str + '/'):
-            return True
-
-    return False
+    return get_ignore_matcher(repo_info).is_ignored(relative_path, is_dir=is_dir)

--- a/beman_tidy/lib/utils/file.py
+++ b/beman_tidy/lib/utils/file.py
@@ -4,26 +4,14 @@
 import os
 from pathlib import Path
 from .comments import determine_comment_type
+from .ignore import DEFAULT_IGNORE_PATTERNS, IgnoreMatcher, get_ignore_matcher
 
 
 def get_repo_ignorable_subdirectories():
     """
     Returns a set of common build and IDE directories to ignore.
     """
-    return {
-        ".git/",
-        "build/",
-        "cmake-build-debug/",
-        "cmake-build-release/",
-        ".idea/",
-        ".vscode/",
-        "__pycache__/",
-        ".pytest_cache/",
-        ".ruff_cache/",
-        "node_modules/",
-        "venv/",
-        "env/",
-    }
+    return set(DEFAULT_IGNORE_PATTERNS)
 
 
 def get_cpp_header_extensions():
@@ -47,14 +35,22 @@ def get_cpp_extensions():
     return get_cpp_header_extensions() | get_cpp_source_extensions()
 
 
-def _is_ignored(path, ignores):
-    path_str = path.as_posix()
+def _as_matcher(ignores, repo_path):
+    """
+    Accept either an IgnoreMatcher or a plain iterable of ignore patterns.
+    """
+    if isinstance(ignores, IgnoreMatcher):
+        return ignores
 
-    for pattern in ignores:
-        clean_pattern = pattern.rstrip("/") # trailing slash is optional
-        if path_str == clean_pattern or path_str.startswith(clean_pattern + "/"):
-            return True
-    return False
+    if ignores is None:
+        ignores = get_repo_ignorable_subdirectories()
+
+    # Pattern order decides which one wins, so only unordered input is sorted.
+    if isinstance(ignores, (set, frozenset)):
+        ignores = sorted(ignores)
+
+    # An explicit list of patterns is the whole story: .gitignore is not added.
+    return get_ignore_matcher(repo_path, ignores, use_gitignore=False)
 
 
 def get_matched_paths(repo_path, extensions, ignores=None):
@@ -62,24 +58,23 @@ def get_matched_paths(repo_path, extensions, ignores=None):
     Get all files in the repository matching the given extensions.
     Ignores paths specified in 'ignores'.
     """
-    if ignores is None:
-        ignores = get_repo_ignorable_subdirectories()
+    repo_path = Path(repo_path)
+    matcher = _as_matcher(ignores, repo_path)
 
     matched_files = []
-    repo_path = Path(repo_path)
 
     for root, dirs, files in os.walk(repo_path):
         rel_root = Path(root).relative_to(repo_path)
 
         for d in list(dirs):
             d_path = rel_root / d
-            if _is_ignored(d_path, ignores):
+            if matcher.is_ignored(d_path, is_dir=True):
                 dirs.remove(d)
 
         for f in files:
             f_path = rel_root / f
             if f_path.suffix in extensions:
-                if not _is_ignored(f_path, ignores):
+                if not matcher.is_ignored(f_path, is_dir=False):
                     matched_files.append(f_path)
 
     return sorted(list(set(matched_files)))
@@ -149,24 +144,23 @@ def get_commentable_files(repo_path, ignores=None):
     Get all files that can contain a comment (and thus should have an SPDX identifier).
     Covers C++, CMake, Python, shell scripts, and YAML files.
     """
-    if ignores is None:
-        ignores = get_repo_ignorable_subdirectories()
+    repo_path = Path(repo_path)
+    matcher = _as_matcher(ignores, repo_path)
 
     matched_files = []
-    repo_path = Path(repo_path)
 
     for root, dirs, files in os.walk(repo_path):
         rel_root = Path(root).relative_to(repo_path)
 
         for d in list(dirs):
             d_path = rel_root / d
-            if _is_ignored(d_path, ignores):
+            if matcher.is_ignored(d_path, is_dir=True):
                 dirs.remove(d)
 
         for f in files:
             f_path = rel_root / f
             if f_path.suffix in COMMENTABLE_EXTENSIONS or f_path.name in COMMENTABLE_FILENAMES:
-                if not _is_ignored(f_path, ignores):
+                if not matcher.is_ignored(f_path, is_dir=False):
                     matched_files.append(f_path)
 
     return sorted(list(set(matched_files)))

--- a/beman_tidy/lib/utils/ignore.py
+++ b/beman_tidy/lib/utils/ignore.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+import logging
+import os
+from functools import lru_cache
+from pathlib import Path
+
+from pathspec import GitIgnoreSpec
+
+from .logger_config import setup_logging
+
+setup_logging()
+
+GITIGNORE_FILENAME = ".gitignore"
+
+# Files that must always be checked, whatever the ignore sources say.
+# .beman-tidy.yaml is validated against these (see validate_config), but a
+# repository's .gitignore is not ours to reject, so a match is only warned about.
+MANDATORY_PATHS = frozenset({"README.md", "LICENSE"})
+
+# Build and IDE directories ignored by default in every repository.
+DEFAULT_IGNORE_PATTERNS = (
+    ".git/",
+    "build/",
+    "cmake-build-debug/",
+    "cmake-build-release/",
+    ".idea/",
+    ".vscode/",
+    "__pycache__/",
+    ".pytest_cache/",
+    ".ruff_cache/",
+    "node_modules/",
+    "venv/",
+    ".venv/",
+    "env/",
+)
+
+
+class IgnoreMatcher:
+    """
+    Matches repository-relative paths against the configured ignore sources.
+
+    Every source uses .gitignore pattern syntax: the built-in defaults, the
+    'ignored_paths' entries of .beman-tidy.yaml and the repository's own
+    .gitignore files.
+
+    Layers are consulted from the highest precedence to the lowest:
+      1. 'ignored_paths' from the beman-tidy configuration
+      2. .gitignore files, deepest directory first
+      3. the built-in defaults
+    The first layer holding a pattern that matches decides, so a negated entry
+    ('!foo') re-includes a path that a lower-precedence layer ignores.
+    """
+
+    def __init__(self, root=None, layers=()):
+        # root is only needed to tell files from directories on disk; matching
+        # itself is purely lexical.
+        self.root = Path(root) if root is not None else None
+        # Each layer is a (base directory, GitIgnoreSpec) pair, with the base
+        # directory relative to the repository root ("." for the root itself).
+        self._layers = list(layers)
+        self._warned_mandatory = set()
+
+    def add_gitignore_layer(self, base, spec):
+        """
+        Add a .gitignore layer below the configuration layer, above every layer
+        added before it.
+        """
+        self._layers.insert(1, (base, spec))
+
+    def is_ignored(self, relative_path, is_dir=None):
+        """
+        Check if a repository-relative path is ignored.
+
+        @param relative_path: The path to check, relative to the repository root.
+        @param is_dir: Whether the path is a directory. Determined from disk when
+                       None, and if the path does not exist, both interpretations
+                       are tried so that e.g. "build/" still matches "build".
+        """
+        rel_path = Path(relative_path).as_posix().strip("/")
+        if not rel_path or rel_path == ".":
+            return False
+
+        # A path under an ignored directory is ignored even if a pattern
+        # re-includes it: git does not allow re-including below an excluded
+        # directory, and the directory is pruned before we ever descend into it.
+        parts = rel_path.split("/")
+        for depth in range(1, len(parts)):
+            if self._check("/".join(parts[:depth]), is_dir=True) is True:
+                return self._allow_ignoring(rel_path)
+
+        if is_dir is None:
+            is_dir = self._probe_is_dir(rel_path)
+
+        if is_dir is None:
+            ignored = self._check(rel_path, is_dir=True) is True or (
+                self._check(rel_path, is_dir=False) is True
+            )
+        else:
+            ignored = self._check(rel_path, is_dir=is_dir) is True
+
+        return self._allow_ignoring(rel_path) if ignored else False
+
+    def _allow_ignoring(self, rel_path):
+        """
+        Keep mandatory files checked, whatever matched them.
+        """
+        if rel_path not in MANDATORY_PATHS:
+            return True
+
+        if rel_path not in self._warned_mandatory:
+            self._warned_mandatory.add(rel_path)
+            logging.warning(
+                f"Warning: '{rel_path}' is ignored by an ignore source, but it is mandatory. Still checking it."
+            )
+        return False
+
+    def _probe_is_dir(self, rel_path):
+        """
+        Determine from disk whether a path is a directory.
+        Returns None if that cannot be determined.
+        """
+        if self.root is None:
+            return None
+
+        path = self.root / rel_path
+        if path.is_dir():
+            return True
+        if path.exists():
+            return False
+        return None
+
+    def _check(self, rel_path, is_dir):
+        """
+        Ask each layer, highest precedence first, whether it matches the path.
+        Returns True (ignored), False (explicitly re-included) or None (no match).
+        """
+        # A trailing slash is what makes directory-only patterns ("build/") match.
+        candidate = f"{rel_path}/" if is_dir else rel_path
+
+        for base, spec in self._layers:
+            scoped_path = _relative_to(candidate, base)
+            if scoped_path is None:
+                continue
+
+            result = spec.check_file(scoped_path)
+            if result.include is not None:
+                return result.include
+
+        return None
+
+
+def _relative_to(candidate, base):
+    """
+    Re-root a repository-relative path onto a layer's base directory.
+    Returns None if the path is outside that directory or is the directory itself.
+    """
+    if base in ("", "."):
+        return candidate
+
+    prefix = f"{base}/"
+    if not candidate.startswith(prefix):
+        return None
+
+    scoped_path = candidate[len(prefix):]
+    # The .gitignore of a directory cannot ignore that directory itself.
+    return scoped_path or None
+
+
+def _read_gitignore_lines(path):
+    """
+    Read the patterns of a .gitignore file. Returns [] if it cannot be read.
+    """
+    try:
+        with open(path, "r", encoding="utf-8", errors="replace") as file:
+            return file.read().splitlines()
+    except OSError as e:
+        logging.warning(f"Warning: could not read '{path}': {e}. Skipping it.")
+        return []
+
+
+def _collect_gitignore_layers(matcher, root):
+    """
+    Add a layer for every .gitignore file in the repository, deepest first.
+
+    Walks top-down and prunes directories that are already ignored, so that a
+    .gitignore inside an ignored directory is never read - which is what git does.
+    """
+    for dir_path, dir_names, file_names in os.walk(root):
+        rel_dir = Path(dir_path).relative_to(root).as_posix()
+
+        if GITIGNORE_FILENAME in file_names:
+            lines = _read_gitignore_lines(Path(dir_path) / GITIGNORE_FILENAME)
+            if lines:
+                # os.walk yields a directory before its subdirectories, so the
+                # most recently added .gitignore is always the deepest one.
+                matcher.add_gitignore_layer(rel_dir, GitIgnoreSpec.from_lines(lines))
+
+        dir_names[:] = [
+            d
+            for d in sorted(dir_names)
+            if not matcher.is_ignored(
+                d if rel_dir == "." else f"{rel_dir}/{d}", is_dir=True
+            )
+        ]
+
+
+def build_ignore_matcher(root, config_patterns=(), use_gitignore=True):
+    """
+    Build an IgnoreMatcher for a repository.
+
+    @param root: The repository root.
+    @param config_patterns: The 'ignored_paths' entries of the configuration.
+    @param use_gitignore: Whether the repository's .gitignore files are honored.
+    """
+    root = Path(root)
+    matcher = IgnoreMatcher(
+        root,
+        [
+            (".", GitIgnoreSpec.from_lines(config_patterns)),
+            (".", GitIgnoreSpec.from_lines(DEFAULT_IGNORE_PATTERNS)),
+        ],
+    )
+
+    if use_gitignore:
+        _collect_gitignore_layers(matcher, root)
+
+    return matcher
+
+
+@lru_cache(maxsize=None)
+def _build_ignore_matcher_cached(root, config_patterns, use_gitignore):
+    return build_ignore_matcher(root, config_patterns, use_gitignore)
+
+
+def get_ignore_matcher(root, config_patterns=(), use_gitignore=True):
+    """
+    Return the IgnoreMatcher for a repository, building it once per repository.
+
+    Scanning for .gitignore files walks the repository, so the result is cached.
+    Call reset_ignore_cache() when the repository contents change underneath.
+    """
+    return _build_ignore_matcher_cached(
+        Path(root).resolve(), tuple(config_patterns), bool(use_gitignore)
+    )
+
+
+def reset_ignore_cache():
+    """
+    Drop the cached matchers. Mostly useful for tests.
+    """
+    _build_ignore_matcher_cached.cache_clear()

--- a/pylock.toml
+++ b/pylock.toml
@@ -5,8 +5,22 @@ created-by = "uv"
 requires-python = ">=3.12"
 
 [[packages]]
+name = "attrs"
+version = "26.1.0"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/9a/8e/82a0fe20a541c03148528be8cac2408564a6c9a0cc7e9171802bc1d26985/attrs-26.1.0.tar.gz", upload-time = 2026-03-19T14:22:25Z, size = 952055, hashes = { sha256 = "d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl", upload-time = 2026-03-19T14:22:23Z, size = 67548, hashes = { sha256 = "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309" } }]
+
+[[packages]]
 name = "beman-tidy"
 directory = { path = ".", editable = true }
+
+[[packages]]
+name = "cmake-parser"
+version = "0.9.2"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/07/47/403d7cae1e6251a8e3581cec3ee74dd843f3bc441865a74e04013a35b83d/cmake_parser-0.9.2.tar.gz", upload-time = 2023-08-28T18:16:00Z, size = 22464, hashes = { sha256 = "b7a313d3f41e58c09e0886f2c98f3fcee2b1897fe7f87449823a53e51ab23a3d" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/91/d5/b18630e6ac33d2e29ad399ca4df1f2ddc94dd8ec1746e42a4661c2a5b3cd/cmake_parser-0.9.2-py3-none-any.whl", upload-time = 2023-08-28T18:15:58Z, size = 19023, hashes = { sha256 = "dd763c10ce118b9ef1ddfa550ac270c28ca443804f41981eae45fcf30c0f7b0b" } }]
 
 [[packages]]
 name = "colorama"
@@ -25,24 +39,31 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5
 
 [[packages]]
 name = "gitpython"
-version = "3.1.44"
+version = "3.1.52"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/c0/89/37df0b71473153574a5cdef8f242de422a0f5d26d7a9e231e6f169b4ad14/gitpython-3.1.44.tar.gz", upload-time = 2025-01-02T07:32:43Z, size = 214196, hashes = { sha256 = "c87e30b26253bf5418b01b0660f818967f3c503193838337fe5e573331249269" } }
-wheels = [{ name = "gitpython-3.1.44-py3-none-any.whl", url = "https://files.pythonhosted.org/packages/1d/9a/4114a9057db2f1462d5c8f8390ab7383925fe1ac012eaa42402ad65c2963/GitPython-3.1.44-py3-none-any.whl", upload-time = 2025-01-02T07:32:40Z, size = 207599, hashes = { sha256 = "9e0e10cda9bed1ee64bc9a6de50e7e38a9c9943241cd7f585f6df3ed28011110" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/fd/df0bafa4eb5ea2f51e1adee9f7a94c8e62c5d180e65117045dfca3439c8a/gitpython-3.1.52.tar.gz", upload-time = 2026-07-16T03:15:59Z, size = 223726, hashes = { sha256 = "de0a8ad86274c6e75ae8b37dd055ba68f19818c813108642263227b20775b48e" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/8d/90/04dff7c1e176bb1c3011ef1647393d368790da710d8dde1cdcfad301f45a/gitpython-3.1.52-py3-none-any.whl", upload-time = 2026-07-16T03:15:58Z, size = 215366, hashes = { sha256 = "79a36ee1f83523214a3f72d56cf1c4e490d577dc61af77e43dfe5862bd9da01a" } }]
 
 [[packages]]
 name = "iniconfig"
-version = "2.1.0"
+version = "2.3.0"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", upload-time = 2025-03-19T20:09:59Z, size = 4793, hashes = { sha256 = "3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", upload-time = 2025-03-19T20:10:01Z, size = 6050, hashes = { sha256 = "9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", upload-time = 2025-10-18T21:55:43Z, size = 20503, hashes = { sha256 = "c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", upload-time = 2025-10-18T21:55:41Z, size = 7484, hashes = { sha256 = "f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12" } }]
 
 [[packages]]
 name = "packaging"
-version = "25.0"
+version = "26.2"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", upload-time = 2025-04-19T11:48:59Z, size = 165727, hashes = { sha256 = "d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", upload-time = 2025-04-19T11:48:57Z, size = 66469, hashes = { sha256 = "29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", upload-time = 2026-04-24T20:15:23Z, size = 228134, hashes = { sha256 = "ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", upload-time = 2026-04-24T20:15:22Z, size = 100195, hashes = { sha256 = "5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e" } }]
+
+[[packages]]
+name = "pathspec"
+version = "1.1.1"
+index = "https://pypi.org/simple"
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", upload-time = 2026-04-27T01:46:08Z, size = 135180, hashes = { sha256 = "17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", upload-time = 2026-04-27T01:46:07Z, size = 57328, hashes = { sha256 = "a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189" } }]
 
 [[packages]]
 name = "pluggy"
@@ -53,17 +74,17 @@ wheels = [{ url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d920
 
 [[packages]]
 name = "pygments"
-version = "2.19.1"
+version = "2.20.0"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/7c/2d/c3338d48ea6cc0feb8446d8e6937e1408088a72a39937982cc6111d17f84/pygments-2.19.1.tar.gz", upload-time = 2025-01-06T17:26:30Z, size = 4968581, hashes = { sha256 = "61c16d2a8576dc0649d9f39e089b5f02bcd27fba10d8fb4dcc28173f7a45151f" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/8a/0b/9fcc47d19c48b59121088dd6da2488a49d5f72dacf8262e2790a1d2c7d15/pygments-2.19.1-py3-none-any.whl", upload-time = 2025-01-06T17:26:25Z, size = 1225293, hashes = { sha256 = "9ea1544ad55cecf4b8242fab6dd35a93bbce657034b0611ee383099054ab6d8c" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", upload-time = 2026-03-29T13:29:33Z, size = 4955991, hashes = { sha256 = "6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", upload-time = 2026-03-29T13:29:30Z, size = 1231151, hashes = { sha256 = "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176" } }]
 
 [[packages]]
 name = "pytest"
-version = "8.4.0"
+version = "9.1.1"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/fb/aa/405082ce2749be5398045152251ac69c0f3578c7077efc53431303af97ce/pytest-8.4.0.tar.gz", upload-time = 2025-06-02T17:36:30Z, size = 1515232, hashes = { sha256 = "14d920b48472ea0dbf68e45b96cd1ffda4705f33307dcc86c676c1b5104838a6" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/2f/de/afa024cbe022b1b318a3d224125aa24939e99b4ff6f22e0ba639a2eaee47/pytest-8.4.0-py3-none-any.whl", upload-time = 2025-06-02T17:36:27Z, size = 363797, hashes = { sha256 = "f40f825768ad76c0977cbacdf1fd37c6f7a468e460ea6a0636078f8972d4517e" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", upload-time = 2026-06-19T10:58:32Z, size = 1636369, hashes = { sha256 = "1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", upload-time = 2026-06-19T10:58:31Z, size = 386536, hashes = { sha256 = "37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c" } }]
 
 [[packages]]
 name = "pyyaml"
@@ -93,32 +114,32 @@ wheels = [
 
 [[packages]]
 name = "ruff"
-version = "0.11.13"
+version = "0.15.21"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/ed/da/9c6f995903b4d9474b39da91d2d626659af3ff1eeb43e9ae7c119349dba6/ruff-0.11.13.tar.gz", upload-time = 2025-06-05T21:00:15Z, size = 4282054, hashes = { sha256 = "26fa247dc68d1d4e72c179e08889a25ac0c7ba4d78aecfc835d49cbfd60bf514" } }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/36/6f65aa9989acdec45d417192d8f4e7921931d8a6cf87ac74bce3eed98a8e/ruff-0.15.21.tar.gz", upload-time = 2026-07-09T20:01:34Z, size = 4769401, hashes = { sha256 = "d0cfc841c572283c36548f82664a54ce6565567f1b0d5b4cf2caac693d8b7500" } }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/ce/a11d381192966e0b4290842cc8d4fac7dc9214ddf627c11c1afff87da29b/ruff-0.11.13-py3-none-linux_armv6l.whl", upload-time = 2025-06-05T20:59:32Z, size = 10292516, hashes = { sha256 = "4bdfbf1240533f40042ec00c9e09a3aade6f8c10b6414cf11b519488d2635d46" } },
-    { url = "https://files.pythonhosted.org/packages/78/db/87c3b59b0d4e753e40b6a3b4a2642dfd1dcaefbff121ddc64d6c8b47ba00/ruff-0.11.13-py3-none-macosx_10_12_x86_64.whl", upload-time = 2025-06-05T20:59:37Z, size = 11106083, hashes = { sha256 = "aef9c9ed1b5ca28bb15c7eac83b8670cf3b20b478195bd49c8d756ba0a36cf48" } },
-    { url = "https://files.pythonhosted.org/packages/77/79/d8cec175856ff810a19825d09ce700265f905c643c69f45d2b737e4a470a/ruff-0.11.13-py3-none-macosx_11_0_arm64.whl", upload-time = 2025-06-05T20:59:39Z, size = 10436024, hashes = { sha256 = "53b15a9dfdce029c842e9a5aebc3855e9ab7771395979ff85b7c1dedb53ddc2b" } },
-    { url = "https://files.pythonhosted.org/packages/8b/5b/f6d94f2980fa1ee854b41568368a2e1252681b9238ab2895e133d303538f/ruff-0.11.13-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", upload-time = 2025-06-05T20:59:42Z, size = 10646324, hashes = { sha256 = "ab153241400789138d13f362c43f7edecc0edfffce2afa6a68434000ecd8f69a" } },
-    { url = "https://files.pythonhosted.org/packages/6c/9c/b4c2acf24ea4426016d511dfdc787f4ce1ceb835f3c5fbdbcb32b1c63bda/ruff-0.11.13-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", upload-time = 2025-06-05T20:59:44Z, size = 10174416, hashes = { sha256 = "6c51f93029d54a910d3d24f7dd0bb909e31b6cd989a5e4ac513f4eb41629f0dc" } },
-    { url = "https://files.pythonhosted.org/packages/f3/10/e2e62f77c65ede8cd032c2ca39c41f48feabedb6e282bfd6073d81bb671d/ruff-0.11.13-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2025-06-05T20:59:46Z, size = 11724197, hashes = { sha256 = "1808b3ed53e1a777c2ef733aca9051dc9bf7c99b26ece15cb59a0320fbdbd629" } },
-    { url = "https://files.pythonhosted.org/packages/bb/f0/466fe8469b85c561e081d798c45f8a1d21e0b4a5ef795a1d7f1a9a9ec182/ruff-0.11.13-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", upload-time = 2025-06-05T20:59:49Z, size = 12511615, hashes = { sha256 = "d28ce58b5ecf0f43c1b71edffabe6ed7f245d5336b17805803312ec9bc665933" } },
-    { url = "https://files.pythonhosted.org/packages/17/0e/cefe778b46dbd0cbcb03a839946c8f80a06f7968eb298aa4d1a4293f3448/ruff-0.11.13-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", upload-time = 2025-06-05T20:59:51Z, size = 12117080, hashes = { sha256 = "55e4bc3a77842da33c16d55b32c6cac1ec5fb0fbec9c8c513bdce76c4f922165" } },
-    { url = "https://files.pythonhosted.org/packages/5d/2c/caaeda564cbe103bed145ea557cb86795b18651b0f6b3ff6a10e84e5a33f/ruff-0.11.13-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", upload-time = 2025-06-05T20:59:54Z, size = 11326315, hashes = { sha256 = "633bf2c6f35678c56ec73189ba6fa19ff1c5e4807a78bf60ef487b9dd272cc71" } },
-    { url = "https://files.pythonhosted.org/packages/75/f0/782e7d681d660eda8c536962920c41309e6dd4ebcea9a2714ed5127d44bd/ruff-0.11.13-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2025-06-05T20:59:56Z, size = 11555640, hashes = { sha256 = "4ffbc82d70424b275b089166310448051afdc6e914fdab90e08df66c43bb5ca9" } },
-    { url = "https://files.pythonhosted.org/packages/5d/d4/3d580c616316c7f07fb3c99dbecfe01fbaea7b6fd9a82b801e72e5de742a/ruff-0.11.13-py3-none-musllinux_1_2_aarch64.whl", upload-time = 2025-06-05T20:59:59Z, size = 10507364, hashes = { sha256 = "4a9ddd3ec62a9a89578c85842b836e4ac832d4a2e0bfaad3b02243f930ceafcc" } },
-    { url = "https://files.pythonhosted.org/packages/5a/dc/195e6f17d7b3ea6b12dc4f3e9de575db7983db187c378d44606e5d503319/ruff-0.11.13-py3-none-musllinux_1_2_armv7l.whl", upload-time = 2025-06-05T21:00:01Z, size = 10141462, hashes = { sha256 = "d237a496e0778d719efb05058c64d28b757c77824e04ffe8796c7436e26712b7" } },
-    { url = "https://files.pythonhosted.org/packages/f4/8e/39a094af6967faa57ecdeacb91bedfb232474ff8c3d20f16a5514e6b3534/ruff-0.11.13-py3-none-musllinux_1_2_i686.whl", upload-time = 2025-06-05T21:00:04Z, size = 11121028, hashes = { sha256 = "26816a218ca6ef02142343fd24c70f7cd8c5aa6c203bca284407adf675984432" } },
-    { url = "https://files.pythonhosted.org/packages/5a/c0/b0b508193b0e8a1654ec683ebab18d309861f8bd64e3a2f9648b80d392cb/ruff-0.11.13-py3-none-musllinux_1_2_x86_64.whl", upload-time = 2025-06-05T21:00:06Z, size = 11602992, hashes = { sha256 = "51c3f95abd9331dc5b87c47ac7f376db5616041173826dfd556cfe3d4977f492" } },
-    { url = "https://files.pythonhosted.org/packages/7c/91/263e33ab93ab09ca06ce4f8f8547a858cc198072f873ebc9be7466790bae/ruff-0.11.13-py3-none-win32.whl", upload-time = 2025-06-05T21:00:08Z, size = 10474944, hashes = { sha256 = "96c27935418e4e8e77a26bb05962817f28b8ef3843a6c6cc49d8783b5507f250" } },
-    { url = "https://files.pythonhosted.org/packages/46/f4/7c27734ac2073aae8efb0119cae6931b6fb48017adf048fdf85c19337afc/ruff-0.11.13-py3-none-win_amd64.whl", upload-time = 2025-06-05T21:00:11Z, size = 11548669, hashes = { sha256 = "29c3189895a8a6a657b7af4e97d330c8a3afd2c9c8f46c81e2fc5a31866517e3" } },
-    { url = "https://files.pythonhosted.org/packages/ec/bf/b273dd11673fed8a6bd46032c0ea2a04b2ac9bfa9c628756a5856ba113b0/ruff-0.11.13-py3-none-win_arm64.whl", upload-time = 2025-06-05T21:00:13Z, size = 10683928, hashes = { sha256 = "b4385285e9179d608ff1d2fb9922062663c658605819a6876d8beef0c30b7f3b" } },
+    { url = "https://files.pythonhosted.org/packages/d0/c6/ede15cac6839f3dbce52565c8f5164a8210e669c7bc4decb03e5bdf47d0d/ruff-0.15.21-py3-none-linux_armv6l.whl", upload-time = 2026-07-09T20:00:53Z, size = 10854342, hashes = { sha256 = "63ea0e965e5d73c90e95b2434beeafc70820536717f561b32ab6e777cb9bdf5d" } },
+    { url = "https://files.pythonhosted.org/packages/28/9d/d825b07ee7ea9e2d61df92a860033c94e06e7300d50a1c2653aac27d24fe/ruff-0.15.21-py3-none-macosx_10_12_x86_64.whl", upload-time = 2026-07-09T20:00:57Z, size = 11139539, hashes = { sha256 = "0f212c5d7d54c01bbfe6dcab02b724a39300f3e34ed7acbe995ccb320a2c58bd" } },
+    { url = "https://files.pythonhosted.org/packages/f5/de/3b107712e642f063c7a9e0887c427b22cb44097de5aab36c05f2e280670c/ruff-0.15.21-py3-none-macosx_11_0_arm64.whl", upload-time = 2026-07-09T20:01:00Z, size = 10595437, hashes = { sha256 = "e6312e41bc96791299614995ea3a977c5857c3b5662b1ecef6755b02b87cb646" } },
+    { url = "https://files.pythonhosted.org/packages/9a/6f/b4523cc90ba239ede441447a19d0c968846a3012e5a0b0c5b62831a3d5e3/ruff-0.15.21-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", upload-time = 2026-07-09T20:01:02Z, size = 10990053, hashes = { sha256 = "01d65b4831c6b2a4ba8ee6faa84049d44d982b7a706e622c4094c509e51673be" } },
+    { url = "https://files.pythonhosted.org/packages/92/cc/c6a9872a5375f0628875481cf2f66b13d7d865bf3ca2e57f91c7e762d976/ruff-0.15.21-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", upload-time = 2026-07-09T20:01:04Z, size = 10666096, hashes = { sha256 = "2c5a913a589120ce67933d5d05fd6ddbcc2481c6a054980ee767f7414c72b4fd" } },
+    { url = "https://files.pythonhosted.org/packages/ab/97/c621f7a17e097f1790fa3af6374138823b330b2d03fc38337945daca212c/ruff-0.15.21-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", upload-time = 2026-07-09T20:01:06Z, size = 11537011, hashes = { sha256 = "5ef04b681d02ad4dc9620f00f83ac5c22f652d0e9a9cfe431d219b16ad5ccc41" } },
+    { url = "https://files.pythonhosted.org/packages/ea/51/d928727e476e25ccc57c6f449ffd80241a651a973ad949d39cfb2a771d28/ruff-0.15.21-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", upload-time = 2026-07-09T20:01:08Z, size = 12347101, hashes = { sha256 = "16d090c0740916594157e75b80d666eab8e78083b39b3b0e1d698f4670a17b86" } },
+    { url = "https://files.pythonhosted.org/packages/1e/88/8cd62026802b16018ad06931d87997cf795ba2a6239ab659606c87d96bf0/ruff-0.15.21-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", upload-time = 2026-07-09T20:01:11Z, size = 11572001, hashes = { sha256 = "3a10e74757dd65004d779b73e2f3c5210156d9980b41224d50d2ebcf1db51e67" } },
+    { url = "https://files.pythonhosted.org/packages/b2/97/f63084cf55444fc110e8cb985ebfcc592af47f597d44453d778cb81bc156/ruff-0.15.21-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", upload-time = 2026-07-09T20:01:13Z, size = 11549239, hashes = { sha256 = "bab0905d2f29e0d9fbc3c373ed23db0095edaa3f71f1f4f519ec15134d9e85c8" } },
+    { url = "https://files.pythonhosted.org/packages/9d/77/f107da4a2874b7715914b03f09ba9c54424de3ff8a1cc5d015d3ee2ce0ac/ruff-0.15.21-py3-none-manylinux_2_31_riscv64.whl", upload-time = 2026-07-09T20:01:15Z, size = 11535340, hashes = { sha256 = "00eca240af5789fec6fe7df74c088cc1f9644ed83027113468efba7c92b94075" } },
+    { url = "https://files.pythonhosted.org/packages/d5/e9/601deb322d3303a7bf212b0100ead6f2ee3f6a044d89c30f2f92bf83c731/ruff-0.15.21-py3-none-musllinux_1_2_aarch64.whl", upload-time = 2026-07-09T20:01:17Z, size = 10964048, hashes = { sha256 = "262ab31557a75141325e32d3357f3597645a7f084e732b6b054dde428ecd9341" } },
+    { url = "https://files.pythonhosted.org/packages/ea/2e/0f2176d1e99c15192caea19c8c3a0a955246b4cb4de795042eeb616345cd/ruff-0.15.21-py3-none-musllinux_1_2_armv7l.whl", upload-time = 2026-07-09T20:01:19Z, size = 10667055, hashes = { sha256 = "659c4e7a4212f83306045ec7c5e5a356d16d9a6ef4ae0c7a4d872914fc655d9d" } },
+    { url = "https://files.pythonhosted.org/packages/48/60/abd74a02e0c4214f12a68becfd30af7165cfdcb0e661ecdc60bbb949c09a/ruff-0.15.21-py3-none-musllinux_1_2_i686.whl", upload-time = 2026-07-09T20:01:21Z, size = 11242043, hashes = { sha256 = "9e866eab611a5f959d36df2d10e446973a3610bc42b0c15b31dc27977d59c233" } },
+    { url = "https://files.pythonhosted.org/packages/b2/c6/583075d8ccabb4b229345edcaf1545eb3d8d6be90f686a479d7e94088bbf/ruff-0.15.21-py3-none-musllinux_1_2_x86_64.whl", upload-time = 2026-07-09T20:01:24Z, size = 11648064, hashes = { sha256 = "e89bc93c0d3803ba870b55c29671bad9dc6d94bb1eb181b056b52eb05b52854f" } },
+    { url = "https://files.pythonhosted.org/packages/3a/3c/37d0ecb729a7cc2d393ea7dce316fc585680f35d93b8d62139d7d0a3700c/ruff-0.15.21-py3-none-win32.whl", upload-time = 2026-07-09T20:01:26Z, size = 10896555, hashes = { sha256 = "01f8d5be84823c172b389e123174f781f9daf86d6c58719d603f941932195cdd" } },
+    { url = "https://files.pythonhosted.org/packages/c0/b8/e43466b2a6067ce91e669068f6e28d6c719a920f014b070d5c8731725de3/ruff-0.15.21-py3-none-win_amd64.whl", upload-time = 2026-07-09T20:01:29Z, size = 12038772, hashes = { sha256 = "d4b8d9a2f0f12b816b50447f6eccb9f4bb01a6b82c86b50fb3b5354b458dc6d3" } },
+    { url = "https://files.pythonhosted.org/packages/dd/75/e90ab9aeece218a9fc5a5bc3ec97d0ee6bb3c4ff95869463c1de58e29a1c/ruff-0.15.21-py3-none-win_arm64.whl", upload-time = 2026-07-09T20:01:31Z, size = 11375265, hashes = { sha256 = "6e83115d4b9377c1cbc13abf0e051f069fab0ef815ea0504a8a008cee24dd0a8" } },
 ]
 
 [[packages]]
 name = "smmap"
-version = "5.0.2"
+version = "5.0.3"
 index = "https://pypi.org/simple"
-sdist = { url = "https://files.pythonhosted.org/packages/44/cd/a040c4b3119bbe532e5b0732286f805445375489fceaec1f48306068ee3b/smmap-5.0.2.tar.gz", upload-time = 2025-01-02T07:14:40Z, size = 22329, hashes = { sha256 = "26ea65a03958fa0c8a1c7e8c7a58fdc77221b8910f6be2131affade476898ad5" } }
-wheels = [{ url = "https://files.pythonhosted.org/packages/04/be/d09147ad1ec7934636ad912901c5fd7667e1c858e19d355237db0d0cd5e4/smmap-5.0.2-py3-none-any.whl", upload-time = 2025-01-02T07:14:38Z, size = 24303, hashes = { sha256 = "b30115f0def7d7531d22a0fb6502488d879e75b260a9db4d0819cfb25403af5e" } }]
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", upload-time = 2026-03-09T03:43:26Z, size = 22506, hashes = { sha256 = "4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c" } }
+wheels = [{ url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", upload-time = 2026-03-09T03:43:24Z, size = 24390, hashes = { sha256 = "c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f" } }]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ maintainers = [{ name = "Rishyak", email = "hello@rishyak.com" }]
 dependencies = [
     "cmake-parser>=0.9.2",
     "gitpython==3.1.52",
+    "pathspec>=0.12.1",
     "pyyaml==6.0.2",
 ]
 keywords = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,8 @@ import pytest
 import os
 from pathlib import Path
 
+from beman_tidy.lib.utils.ignore import reset_ignore_cache
+
 
 def pytest_configure(config):
     """
@@ -28,4 +30,9 @@ def _setup_test_environment():
     if str(root_dir) not in os.environ.get("PYTHONPATH", ""):
         os.environ["PYTHONPATH"] = f"{root_dir}:{os.environ.get('PYTHONPATH', '')}"
 
+    # Ignore matchers are cached per repository root, and tests reuse roots.
+    reset_ignore_cache()
+
     yield
+
+    reset_ignore_cache()

--- a/tests/lib/utils/test_config.py
+++ b/tests/lib/utils/test_config.py
@@ -67,6 +67,17 @@ def test_validate_config_root_ignored(capsys):
     captured = capsys.readouterr()
     assert "Error: Cannot ignore root directory" in captured.out
 
+def test_validate_config_use_gitignore(capsys):
+    """Test that 'use_gitignore' must be a boolean."""
+    assert validate_config({"use_gitignore": True}) is True
+    assert validate_config({"use_gitignore": False}) is True
+    # Omitting it is valid: .gitignore is honored by default.
+    assert validate_config({}) is True
+
+    assert validate_config({"use_gitignore": "yes"}) is False
+    captured = capsys.readouterr()
+    assert "Error: 'use_gitignore' in .beman-tidy.yaml must be a boolean" in captured.out
+
 def test_load_repo_config_default(tmp_path):
     """Test loading the default configuration file and merging with user config."""
     default_config_path = get_default_config_path()

--- a/tests/lib/utils/test_config_gitignore.py
+++ b/tests/lib/utils/test_config_gitignore.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+from pathlib import Path
+
+import pytest
+
+from beman_tidy.lib.utils.config import is_ignored
+from beman_tidy.lib.utils.file import get_cpp_files, get_matched_paths
+
+
+def make_repo(root, files):
+    """
+    Create a repository layout: a {relative path: content} mapping.
+    """
+    for relative_path, content in files.items():
+        path = root / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+    return root
+
+
+def repo_info_for(root, **config):
+    return {"top_level": root, "config": config}
+
+
+def test_gitignore_is_honored_by_default(tmp_path):
+    """Test that .gitignore patterns are applied without any configuration."""
+    root = make_repo(tmp_path, {".gitignore": "*.pyc\nbuild/\n"})
+    repo_info = repo_info_for(root)
+
+    assert is_ignored(repo_info, Path("a.pyc")) is True
+    assert is_ignored(repo_info, Path("nested/a.pyc")) is True
+    assert is_ignored(repo_info, Path("build")) is True
+    assert is_ignored(repo_info, Path("build/main.o")) is True
+    assert is_ignored(repo_info, Path("src/main.cpp")) is False
+
+
+def test_gitignore_can_be_disabled(tmp_path):
+    """Test that use_gitignore: false turns the .gitignore source off."""
+    root = make_repo(tmp_path, {".gitignore": "*.pyc\ngenerated/\n"})
+    repo_info = repo_info_for(root, use_gitignore=False)
+
+    assert is_ignored(repo_info, Path("a.pyc")) is False
+    assert is_ignored(repo_info, Path("generated/a.cpp")) is False
+    # The built-in ignores still apply.
+    assert is_ignored(repo_info, Path("build/main.o")) is True
+
+
+def test_missing_gitignore(tmp_path):
+    """Test that a repository without a .gitignore behaves as before."""
+    root = make_repo(tmp_path, {"src/main.cpp": ""})
+    repo_info = repo_info_for(root)
+
+    assert is_ignored(repo_info, Path("src/main.cpp")) is False
+    assert is_ignored(repo_info, Path("build/main.o")) is True
+
+
+@pytest.mark.parametrize(
+    "pattern, ignored, not_ignored",
+    [
+        # Comments and blank lines are not patterns.
+        ("# comment\n\nsecret.txt\n", "secret.txt", "comment"),
+        # A leading slash anchors a pattern to the repository root.
+        ("/build_root\n", "build_root", "nested/build_root"),
+        # Without a slash, a pattern matches at any depth.
+        ("generated\n", "a/b/generated/f.cpp", "src/main.cpp"),
+        # '**' spans directories.
+        ("**/vendor/**\n", "a/vendor/b/c.cpp", "a/vendors/b.cpp"),
+        # A trailing slash restricts a pattern to directories.
+        ("logs/\n", "logs/today.txt", "logs.txt"),
+        # Character ranges are supported.
+        ("*.o[123]\n", "a.o2", "a.o4"),
+        # An escaped '!' is a literal, not a negation.
+        ("\\!important.txt\n", "!important.txt", "important.txt"),
+    ],
+)
+def test_gitignore_pattern_syntax(tmp_path, pattern, ignored, not_ignored):
+    """Test that .gitignore pattern syntax is interpreted the way git does."""
+    root = make_repo(tmp_path, {".gitignore": pattern})
+    repo_info = repo_info_for(root)
+
+    assert is_ignored(repo_info, Path(ignored)) is True
+    assert is_ignored(repo_info, Path(not_ignored)) is False
+
+
+def test_gitignore_negation(tmp_path):
+    """Test that a negated pattern re-includes a path."""
+    root = make_repo(tmp_path, {".gitignore": "*.hpp\n!keep.hpp\n"})
+    repo_info = repo_info_for(root)
+
+    assert is_ignored(repo_info, Path("a.hpp")) is True
+    assert is_ignored(repo_info, Path("keep.hpp")) is False
+
+
+def test_gitignore_negation_under_ignored_directory(tmp_path):
+    """Test that a path under an ignored directory cannot be re-included."""
+    root = make_repo(tmp_path, {".gitignore": "generated/\n!generated/keep.hpp\n"})
+    repo_info = repo_info_for(root)
+
+    # git: "It is not possible to re-include a file if a parent directory of
+    # that file is excluded."
+    assert is_ignored(repo_info, Path("generated/keep.hpp")) is True
+
+
+def test_nested_gitignore(tmp_path):
+    """Test that a .gitignore applies relative to its own directory."""
+    root = make_repo(
+        tmp_path,
+        {
+            ".gitignore": "root_only.txt\n",
+            "docs/.gitignore": "draft.md\n",
+        },
+    )
+    repo_info = repo_info_for(root)
+
+    assert is_ignored(repo_info, Path("docs/draft.md")) is True
+    # The nested pattern does not leak outside its directory.
+    assert is_ignored(repo_info, Path("draft.md")) is False
+    # The root pattern still applies inside the nested directory.
+    assert is_ignored(repo_info, Path("docs/root_only.txt")) is True
+
+
+def test_nested_gitignore_overrides_parent(tmp_path):
+    """Test that the deepest .gitignore wins."""
+    root = make_repo(
+        tmp_path,
+        {
+            ".gitignore": "*.md\n",
+            "docs/.gitignore": "!published.md\n",
+        },
+    )
+    repo_info = repo_info_for(root)
+
+    assert is_ignored(repo_info, Path("docs/published.md")) is False
+    assert is_ignored(repo_info, Path("docs/draft.md")) is True
+    assert is_ignored(repo_info, Path("published.md")) is True
+
+
+def test_nested_gitignore_inside_ignored_directory_is_not_read(tmp_path):
+    """Test that a .gitignore below an ignored directory is never applied."""
+    root = make_repo(
+        tmp_path,
+        {
+            ".gitignore": "vendor/\n",
+            "vendor/.gitignore": "!keep.cpp\n",
+        },
+    )
+    repo_info = repo_info_for(root)
+
+    assert is_ignored(repo_info, Path("vendor/keep.cpp")) is True
+
+
+def test_config_overrides_gitignore(tmp_path):
+    """Test that ignored_paths has the last word over .gitignore."""
+    root = make_repo(tmp_path, {".gitignore": "*.hpp\n"})
+    repo_info = repo_info_for(root, ignored_paths=["!include/beman/api.hpp"])
+
+    # Re-included by the configuration...
+    assert is_ignored(repo_info, Path("include/beman/api.hpp")) is False
+    # ...while everything else the .gitignore covers stays ignored.
+    assert is_ignored(repo_info, Path("include/beman/other.hpp")) is True
+
+
+def test_config_cannot_rescue_paths_below_an_ignored_directory(tmp_path):
+    """Test that not even ignored_paths can re-include below an ignored directory."""
+    root = make_repo(tmp_path, {".gitignore": "generated/\n"})
+    repo_info = repo_info_for(root, ignored_paths=["!generated/api.hpp"])
+
+    # git excludes the whole directory, so nothing below it can come back:
+    # the repository has to ignore 'generated/*' rather than 'generated/'.
+    assert is_ignored(repo_info, Path("generated/api.hpp")) is True
+
+
+def test_config_rescues_paths_below_an_ignored_directory_content_pattern(tmp_path):
+    """Test the git idiom for re-including: ignore the contents, not the directory."""
+    root = make_repo(tmp_path, {".gitignore": "generated/*\n"})
+    repo_info = repo_info_for(root, ignored_paths=["!generated/api.hpp"])
+
+    assert is_ignored(repo_info, Path("generated/api.hpp")) is False
+    assert is_ignored(repo_info, Path("generated/other.hpp")) is True
+
+
+def test_config_patterns_use_gitignore_syntax(tmp_path):
+    """Test that ignored_paths entries accept .gitignore pattern syntax."""
+    root = make_repo(tmp_path, {"src/main.cpp": ""})
+    repo_info = repo_info_for(
+        root,
+        ignored_paths=["*.inc", "/anchored.hpp", "**/detail/**"],
+        use_gitignore=False,
+    )
+
+    assert is_ignored(repo_info, Path("a/b.inc")) is True
+    assert is_ignored(repo_info, Path("anchored.hpp")) is True
+    assert is_ignored(repo_info, Path("nested/anchored.hpp")) is False
+    assert is_ignored(repo_info, Path("include/detail/impl.hpp")) is True
+
+
+def test_mandatory_files_are_never_ignored(tmp_path, caplog):
+    """Test that a .gitignore cannot exclude README.md or LICENSE."""
+    root = make_repo(tmp_path, {".gitignore": "README.md\nLICENSE\n*.md\n"})
+    repo_info = repo_info_for(root)
+
+    assert is_ignored(repo_info, Path("README.md")) is False
+    assert is_ignored(repo_info, Path("LICENSE")) is False
+    assert "mandatory" in caplog.text
+    # Other markdown files are still ignored.
+    assert is_ignored(repo_info, Path("CHANGELOG.md")) is True
+
+
+def test_gitignore_applies_to_file_generators(tmp_path):
+    """Test that the file generators skip .gitignore-ignored paths."""
+    root = make_repo(
+        tmp_path,
+        {
+            ".gitignore": "generated/\nscratch.cpp\n",
+            "src/main.cpp": "",
+            "src/scratch.cpp": "",
+            "generated/api.cpp": "",
+            "generated/.gitignore": "!api.cpp\n",
+        },
+    )
+    repo_info = repo_info_for(root)
+
+    from beman_tidy.lib.utils.config import get_ignore_matcher
+
+    found = get_cpp_files(root, ignores=get_ignore_matcher(repo_info))
+
+    assert found == [Path("src/main.cpp")]
+
+
+def test_generators_accept_plain_pattern_lists(tmp_path):
+    """Test that the generators still accept a plain list of patterns."""
+    root = make_repo(tmp_path, {"src/main.cpp": "", "src/gen/a.cpp": ""})
+
+    found = get_matched_paths(root, {".cpp"}, ignores=["gen/"])
+
+    assert found == [Path("src/main.cpp")]
+
+
+def test_generators_keep_pattern_list_order(tmp_path):
+    """Test that a caller's pattern order is not rearranged: the last match wins."""
+    root = make_repo(tmp_path, {"gen/a.cpp": "", "gen/keep.cpp": ""})
+
+    found = get_matched_paths(root, {".cpp"}, ignores=["gen/*", "!gen/keep.cpp"])
+
+    assert found == [Path("gen/keep.cpp")]

--- a/tests/lib/utils/test_config_ignored_files.py
+++ b/tests/lib/utils/test_config_ignored_files.py
@@ -4,11 +4,15 @@
 from pathlib import Path
 from beman_tidy.lib.utils.config import is_ignored
 
+# These tests cover the 'ignored_paths' patterns alone, so .gitignore is off:
+# see test_config_gitignore.py for how the two sources combine.
+
 def test_is_ignored_exact_file():
     """Test that an exact file path is correctly identified as ignored."""
     repo_info = {
         "config": {
-            "ignored_paths": ["include/beman/optional/config.hpp"]
+            "ignored_paths": ["include/beman/optional/config.hpp"],
+            "use_gitignore": False,
         }
     }
     # Path is ignored
@@ -20,7 +24,8 @@ def test_is_ignored_directory():
     """Test that ignoring a directory also ignores all its contents."""
     repo_info = {
         "config": {
-            "ignored_paths": ["build/"]
+            "ignored_paths": ["build/"],
+            "use_gitignore": False,
         }
     }
     # Exact directory match
@@ -36,7 +41,8 @@ def test_is_ignored_multiple_paths():
     """Test that multiple ignored paths are all respected."""
     repo_info = {
         "config": {
-            "ignored_paths": ["build/", "temp.txt", "docs/internal/"]
+            "ignored_paths": ["build/", "temp.txt", "docs/internal/"],
+            "use_gitignore": False,
         }
     }
     assert is_ignored(repo_info, Path("build/file.txt")) is True
@@ -46,14 +52,15 @@ def test_is_ignored_multiple_paths():
 
 def test_is_ignored_no_config():
     """Test behavior when no ignored_paths are configured."""
-    repo_info = {"config": {}}
+    repo_info = {"config": {"use_gitignore": False}}
     assert is_ignored(repo_info, Path("src/main.cpp")) is False
 
 def test_is_ignored_slash_handling():
     """Test that trailing slashes in config don't affect matching consistency."""
     repo_info = {
         "config": {
-            "ignored_paths": ["build", "docs/"]
+            "ignored_paths": ["build", "docs/"],
+            "use_gitignore": False,
         }
     }
     # Both should work whether or not they have a trailing slash in config

--- a/uv.lock
+++ b/uv.lock
@@ -18,6 +18,7 @@ source = { editable = "." }
 dependencies = [
     { name = "cmake-parser" },
     { name = "gitpython" },
+    { name = "pathspec" },
     { name = "pyyaml" },
 ]
 
@@ -31,6 +32,7 @@ dev = [
 requires-dist = [
     { name = "cmake-parser", specifier = ">=0.9.2" },
     { name = "gitpython", specifier = "==3.1.52" },
+    { name = "pathspec", specifier = ">=0.12.1" },
     { name = "pyyaml", specifier = "==6.0.2" },
 ]
 
@@ -101,6 +103,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pathspec"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`beman-tidy` ignored only what `.beman-tidy.yaml` listed, matching exactly and by prefix. A repository had to repeat in its configuration what its `.gitignore` already said, and could not express a pattern at all.

This change routes ignore matching through an `IgnoreMatcher` built on [`pathspec`](https://pypi.org/project/pathspec/), so every ignore source speaks `.gitignore` pattern syntax:

- the repository's `.gitignore` files are honored, including nested ones, each relative to its own directory
- `ignored_paths` entries accept wildcards, `**`, leading `/` anchoring, trailing `/` for directories, and `!` to re-include
- the built-in ignores (`build/`, `__pycache__/`, IDE directories, ...) are patterns too

Sources are consulted from `ignored_paths`, through the `.gitignore` files deepest-first, down to the built-in ignores; the first matching pattern decides. A `!` entry in the configuration therefore re-includes a path that a `.gitignore` covers.

## Behavior notes

- **Opt out** with `use_gitignore: false` in `.beman-tidy.yaml`.
- **`README.md` and `LICENSE` stay mandatory.** `validate_config` already rejects them in `ignored_paths`; a `.gitignore` matching them is not a configuration error, so it warns and the checks still run.
- **Git's re-inclusion rule is kept as-is:** a path below an ignored *directory* cannot be brought back, not even from `ignored_paths`. With `generated/` in a `.gitignore`, no `!generated/api.hpp` works — the repository has to ignore `generated/*` instead. Relaxing this would desynchronize `is_ignored()` from the directory pruning in the tree walk.
- **Two widenings** follow from gitignore semantics: a slashless `ignored_paths` entry such as `docs` now matches at any depth rather than only at the root, and the built-in `build/` now matches nested build directories.
- **`.venv/` added to the built-in ignores.** The defaults now also bound how much of the tree is walked when collecting `.gitignore` files.

## Verification

- Full suite: 137 passed, 24 skipped. `ruff check` clean.
- Run against a fresh clone of `bemanproject/exemplar`: reported checks and coverage are byte-identical before and after this change.
- Positive control on the same clone: a `.cache/scratch.cpp` file — matched by exemplar's `/.cache` entry — is reported before the change and skipped after it.

## Changes

- `beman_tidy/lib/utils/ignore.py` (new): `IgnoreMatcher`, layered specs, `.gitignore` collection, per-root cache
- `beman_tidy/lib/utils/config.py`: `get_ignore_matcher()` replaces `get_ignores()`; `use_gitignore` validated as a boolean
- `beman_tidy/lib/utils/file.py`: the duplicate prefix matcher is gone; both file generators use the shared matcher
- `tests/lib/utils/test_config_gitignore.py` (new): 23 tests covering pattern syntax, nesting, precedence, the mandatory files and the generators
- `README.md`: configuration section and two FAQ entries
- `pyproject.toml` / `uv.lock` / `pylock.toml`: `pathspec>=0.12.1`, lockfiles regenerated per `docs/dev-guide.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)